### PR TITLE
Custom stream implementation to support colors natively, and not be reliant on llvm's raw_ostream.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     src/sema/binder.cpp
     src/codegen/llvm_codegen.cpp
     src/driver/driver.cpp
+    src/utils/stream.cpp
 )
 
 add_executable(zapc ${SOURCES})

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -7,6 +7,7 @@
 #include "sema/binder.hpp"
 #include "sema/bound_nodes.hpp"
 #include "utils/diagnostics.hpp"
+#include "utils/stream.hpp"
 #include <algorithm>
 #include <cerrno>
 #include <cstring>
@@ -17,11 +18,6 @@
 namespace zap {
 
 driver::driver() {}
-
-void print_red(std::string_view msg) {
-  // Simple ANSI colors
-  std::cerr << "\033[1;31m" << msg << "\033[0m";
-}
 
 bool driver::parseArgs(int argc, char **argv) {
   std::vector<std::string_view> args;
@@ -41,28 +37,28 @@ bool driver::parseArgs(int argc, char **argv) {
     auto arg = args[i];
 
     if (arg == "--help") {
-      std::cout << "Zap Compiler [options] <file>\n"
-                << "Zap Compiler\n\n"
-                << "Options:\n"
-                << "  --help          Display available options\n"
-                << "  --version       Print version information\n"
-                << "  -o <file>       Write output to <file>\n"
-                << "  -nostdlib       Stops the linker from linking the zap stdlib\n"
-                << "  -c              Compile and assemble but not link\n"
-                << "  -S              Compile only no assembling or linking\n"
-                << "  -emit-llvm      Emit LLVM IR instead of final output\n"
-                << "  -emit-zir       Emit ZIR instead of final output\n";
+      out()
+          << "Zap Compiler [options] <file>\n"
+          << "Zap Compiler\n\n"
+          << "Options:\n"
+          << "  --help          Display available options\n"
+          << "  --version       Print version information\n"
+          << "  -o <file>       Write output to <file>\n"
+          << "  -nostdlib       Stops the linker from linking the zap stdlib\n"
+          << "  -c              Compile and assemble but not link\n"
+          << "  -S              Compile only no assembling or linking\n"
+          << "  -emit-llvm      Emit LLVM IR instead of final output\n"
+          << "  -emit-zir       Emit ZIR instead of final output\n";
       return false;
     } else if (arg == "--version") {
-      std::cout << "Zap Compiler v" << zap::ZAP_VERSION << '\n';
+      out() << "Zap Compiler v" << zap::ZAP_VERSION << '\n';
       return false;
     } else if (arg == "-o") {
       if (i + 1 < args.size()) {
         output_str = args[++i];
         implicit_output = false;
       } else {
-        print_red("error: ");
-        std::cerr << "argument to '-o' is missing\n";
+        reportError("argument to '-o' is missing");
         return false;
       }
     } else if (arg.substr(0, 2) == "-o") {
@@ -79,8 +75,7 @@ bool driver::parseArgs(int argc, char **argv) {
     } else if (arg == "-emit-zir") {
       emit_zir = true;
     } else if (arg.substr(0, 1) == "-") {
-      print_red("error: ");
-      std::cerr << "unknown argument: " << arg << "\n";
+      reportError("unknown argument: ", arg);
       return false;
     } else {
       inputs.emplace_back(std::string(arg));
@@ -88,8 +83,7 @@ bool driver::parseArgs(int argc, char **argv) {
   }
 
   if (emit_llvm && emit_zir) {
-    print_red("error: ");
-    std::cerr << "choosing multiple emit modes isn't allowed\n";
+    reportError("choosing multiple emit modes isn't allowed");
     return false;
   }
 
@@ -116,9 +110,7 @@ bool driver::parseArgs(int argc, char **argv) {
     return true;
   }
 
-  std::cerr << "zapc: ";
-  print_red("error: ");
-  std::cerr << "no input files\n";
+  reportError("no input files");
   return false;
 }
 
@@ -133,8 +125,7 @@ bool driver::splitInputs() {
     } else if (ext == ".a" || ext == ".o") {
       objects.emplace_back(std::move(input_path));
     } else {
-      print_red("error: ");
-      std::cerr << "unknown input type: " << input << '\n';
+      reportError("unknown input type: ", input);
       return true;
     }
   }
@@ -148,22 +139,18 @@ bool driver::verifyOutput() {
   bool per_file_emit = (emit_type != output_type::EXEC);
 
   if (per_file_emit && get_inputs().size() > 1 && !is_implicit_output()) {
-    print_red("error: ");
-    std::cerr << "cannot specify -o with multiple input files\n";
+    reportError("cannot specify -o with multiple input files");
     return true;
   }
 
   if (per_file_emit && !objects.empty()) {
-    print_red("error: ");
-    std::cerr << "cannot use object files or archives with the selected "
-                    "output mode\n";
+    reportError(
+        "cannot use object files or archives with the selected output mode");
     return true;
   }
 
   if (!format_supported()) {
-    print_red("error: ");
-    std::cerr
-        << "chosen file output mode is not yet supported in this version\n";
+    reportError("chosen file output mode is not yet supported in this version");
     return true;
   }
 
@@ -172,12 +159,10 @@ bool driver::verifyOutput() {
 
 bool verifyFile(const std::filesystem::path &input) {
   if (!std::filesystem::exists(input)) {
-    print_red("error: ");
-    std::cerr << "provided file doesn't exist: " << input << '\n';
+    driver::reportError("provided file doesn't exist: ", input);
     return true;
   } else if (!std::filesystem::is_regular_file(input)) {
-    print_red("error: ");
-    std::cerr << "provided file isn't a regular file: " << input << '\n';
+    driver::reportError("provided file isn't a regular file: ", input);
     return true;
   }
   return false;
@@ -201,8 +186,7 @@ bool compileSourceZIR(sema::BoundRootNode &node, std::ostream &ofoutput) {
   if (mod) {
     ofoutput << mod->toString();
   } else {
-    print_red("error: ");
-    std::cerr << "failed to generate ZIR\n";
+    driver::reportError("failed to generate ZIR");
     return true;
   }
   return false;
@@ -223,8 +207,7 @@ bool driver::compileSourceFile(const std::string &source,
   }
 
   if (!ast) {
-    print_red("error: ");
-    std::cerr << source_name << ": " << "failed parsing the provided file\n";
+    reportError(source_name, ": failed parsing the provided file");
     return true;
   }
 
@@ -232,8 +215,7 @@ bool driver::compileSourceFile(const std::string &source,
   auto boundAst = binder.bind(*ast);
 
   if (!boundAst) {
-    print_red("error: ");
-    std::cerr << source_name << ": " << "semantic analysis failed\n";
+    reportError(source_name, ": semantic analysis failed");
     return true;
   }
 
@@ -258,8 +240,7 @@ bool driver::compileSourceFile(const std::string &source,
     llvmGen.generate(*boundAst);
 
     if (!llvmGen.emitObjectFile(out_path.string())) {
-      print_red("error: ");
-      std::cerr << "object file emission failed\n";
+      reportError("object file emission failed");
       return true;
     }
 
@@ -273,9 +254,8 @@ bool driver::compileSourceFile(const std::string &source,
     std::ofstream ofoutput(out_path, std::ios::binary);
 
     if (!ofoutput) {
-      print_red("error: ");
-      std::cerr << "couldn't open the provided file: " << out_path << '\n';
-      std::cerr << "reason: " << strerror(errno) << '\n';
+      reportError("couldn't open the provided file: ", out_path,
+                  "\nreason: ", strerror(errno));
       return true;
     }
 
@@ -304,9 +284,8 @@ bool driver::compile() {
   for (const std::filesystem::path &input : sources) {
     std::ifstream file(input, std::ios::binary | std::ios::ate);
     if (!file) {
-      print_red("error: ");
-      std::cerr << "couldn't open the provided file: " << input << '\n';
-      std::cerr << "reason: " << strerror(errno) << '\n';
+      reportError("couldn't open the provided file: ", input,
+                  "\nreason: ", strerror(errno));
       return true;
     }
 
@@ -314,7 +293,7 @@ bool driver::compile() {
     std::string content(size, '\0');
 
     if (size == 0) {
-      std::cerr << "warning: provided file is empty: " << input << '\n';
+      err() << "warning: provided file is empty: " << input << '\n';
     } else {
       file.seekg(0);
       file.read(content.data(), size);
@@ -349,8 +328,7 @@ bool driver::link() {
 
   int res = std::system(cmd.c_str());
   if (res != 0) {
-    print_red("error: ");
-    std::cerr << "linking failed with exit code: " << res << '\n';
+    reportError("linking failed with exit code: ", res);
     return true;
   }
 
@@ -365,8 +343,7 @@ bool driver::cleanup() {
     std::filesystem::remove(f, ec);
     if (ec) {
       errs = true;
-      std::cerr << "warning: failed to remove: " << f
-                   << "\nreason: " << ec.message() << '\n';
+      reportWarning("failed to remove: ", f, "\nreason: ", ec.message());
     }
   }
 

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "utils/stream.hpp"
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -158,6 +159,20 @@ public:
       return false;
     }
     return false;
+  }
+
+  template <typename... Args> static void reportError(Args &&...args) {
+    ((err() << "zapc: ").changeColor(Color::RED, true) << "error: ")
+        .resetColor();
+    (err() << ... << args);
+    err() << '\n';
+  }
+
+  template <typename... Args> static void reportWarning(Args &&...args) {
+    ((err() << "zapc: ").changeColor(Color::YELLOW, true) << "warning: ")
+        .resetColor();
+    (err() << ... << args);
+    err() << '\n';
   }
 
 private:

--- a/src/driver/version.hpp
+++ b/src/driver/version.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <llvm/Support/raw_ostream.h>
+#include "utils/stream.hpp"
 #include <ostream>
 
 namespace zap {
@@ -25,8 +25,7 @@ public:
     return os << v.get_major() << '.' << v.get_minor() << '.' << v.get_patch();
   }
 
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
-                                       const _version_base &v) {
+  friend Stream &operator<<(Stream &os, const _version_base &v) {
     return os << v.get_major() << '.' << v.get_minor() << '.' << v.get_patch();
   }
 };

--- a/src/utils/stream.cpp
+++ b/src/utils/stream.cpp
@@ -1,0 +1,121 @@
+#include "utils/stream.hpp"
+#include <algorithm>
+#include <cstring>
+
+namespace zap {
+
+ColorOverride color_override = ColorOverride::AUTO;
+
+Stream::Stream(size_t bufferSize) {
+  start = cur = end = nullptr;
+
+  if (bufferSize) {
+    setBufferSize(bufferSize);
+  }
+}
+
+void Stream::setBufferSize(size_t bufferSize) {
+  if (bufferSize == getBufferSize())
+    return;
+
+  flush();
+  delete[] start;
+
+  start = cur = end = nullptr;
+
+  if (bufferSize) {
+    start = cur = new BufferChar[bufferSize];
+    end = start + bufferSize;
+  }
+}
+
+Stream &Stream::write(const BufferChar *ptr, size_t size) {
+  size_t bufferSize = getBufferSize();
+
+  if (!bufferSize) {
+    internalWrite(ptr, size);
+    return *this;
+  }
+
+  size_t bytesLeft = size;
+  while (bytesLeft) {
+    size_t spaceLeft = end - cur;
+
+    if (bytesLeft >= bufferSize) {
+      flush();
+      internalWrite(ptr, size);
+      break;
+    }
+
+    if (!spaceLeft) {
+      flush();
+      spaceLeft = bufferSize;
+    }
+
+    size_t toCpy = std::min(bytesLeft, spaceLeft);
+
+    std::memcpy(cur, ptr, toCpy);
+
+    cur += toCpy;
+    ptr += toCpy;
+    bytesLeft -= toCpy;
+  }
+
+  return *this;
+}
+
+struct HandleColors {
+  bool stdout_color;
+  bool stdout_tty;
+  bool stderr_color;
+  bool stderr_tty;
+
+  HandleColors();
+};
+
+static HandleColors standard_stream_colors;
+
+class StdoutStream : public SFStream {
+public:
+  using SFStream::SFStream;
+
+  bool hasColors() const override {
+    return standard_stream_colors.stdout_color;
+  }
+
+  bool onTTY() const override { return standard_stream_colors.stdout_tty; }
+};
+
+class StderrStream : public SFStream {
+public:
+  using SFStream::SFStream;
+
+  bool hasColors() const override {
+    return standard_stream_colors.stderr_color;
+  }
+
+  bool onTTY() const override { return standard_stream_colors.stderr_tty; }
+};
+
+Stream &err() {
+  static StderrStream stderrStream(stderr, false);
+  return stderrStream;
+}
+
+Stream &out() {
+  static StdoutStream stdoutStream(stdout, false);
+  return stdoutStream;
+}
+
+/// This is where it is platform dependent.
+HandleColors::HandleColors() {
+  // Asssume colors do exist, ideally this should be implemented for every
+  // platform.
+  stdout_color = true;
+  stdout_tty = true;
+
+  stderr_color = true;
+  stderr_tty = true;
+}
+
+} // namespace zap

--- a/src/utils/stream.hpp
+++ b/src/utils/stream.hpp
@@ -1,0 +1,197 @@
+#pragma once
+
+#include <charconv>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <string>
+
+namespace zap {
+
+/// @brief Allows to override if colors are allowed or not.
+enum class ColorOverride : uint8_t { AUTO, ALWAYS, NEVER };
+extern ColorOverride color_override;
+
+enum class Color {
+  BLACK = 30,
+  RED,
+  GREEN,
+  YELLOW,
+  BLUE,
+  MAGENTA,
+  CYAN,
+  WHITE,
+  BRIGHT_BLACK = 90,
+  BRIGHT_RED,
+  BRIGHT_GREEN,
+  BRIGHT_YELLOW,
+  BRIGHT_BLUE,
+  BRIGHT_MAGENTA,
+  BRIGHT_CYAN,
+  BRIGHT_WHITE
+};
+
+/// @brief A base stream class.
+class Stream {
+public:
+  using BufferChar = char;
+  using BufferType = BufferChar *;
+
+  /// @brief Default buffer size if the buffer size arg is not set.
+  constexpr static size_t DEFAULT_BUFFER_SIZE = 0x2000;
+
+private:
+  BufferType start, cur, end;
+
+  /// @brief Implementation for the write function, depends on the class.
+  virtual void internalWrite(const BufferChar *ptr, size_t size) = 0;
+
+  virtual void internalFlush() {}
+
+public:
+  Stream(const Stream &) = delete;
+  Stream &operator=(const Stream &) = delete;
+
+  /// @brief Default stream constructor.
+  /// @param bufferSize What buffer size should it be, 0 for unbuffered.
+  Stream(size_t bufferSize = DEFAULT_BUFFER_SIZE);
+
+  size_t getBufferSize() const noexcept { return end - cur; }
+
+  /// @brief Writes the provided characters to the stream.
+  /// @param ptr Pointer to the characters.
+  /// @param size How many of them.
+  Stream &write(const BufferChar *ptr, size_t size);
+
+  /// @brief Sets the buffer size of the stream.
+  void setBufferSize(size_t bufferSize = DEFAULT_BUFFER_SIZE);
+
+  /// @brief Makes the stream unbuffered.
+  void setNoBuffer() noexcept { setBufferSize(0); }
+
+  void flush() {
+    if (cur != start) {
+      internalWrite(start, cur - start);
+      cur = start;
+    }
+    internalFlush();
+  }
+
+  /// @brief Returns whether or not the stream is in a console/terminal.
+  virtual bool onTTY() const { return false; }
+
+  /// @brief Returns whether or not this stream supports colors.
+  virtual bool hasColors() const { return false; }
+
+  virtual ~Stream() noexcept { setNoBuffer(); }
+
+  Stream &operator<<(std::nullptr_t) { return write("null", 4); }
+
+  Stream &operator<<(char c) { return write(&c, sizeof(c)); }
+
+  Stream &operator<<(unsigned char c) { return *this << char(c); }
+
+  Stream &operator<<(signed char c) { return *this << char(c); }
+
+  Stream &operator<<(bool b) {
+    return b ? write("true", 4) : write("false", 5);
+  }
+
+  Stream &operator<<(const void *ptr) {
+    char buff[sizeof(void *) * 2 + 2];
+
+    auto res = std::to_chars(buff, buff + sizeof(buff), (uintptr_t)ptr, 16);
+    if (res.ec == std::errc()) {
+      write(buff, res.ptr - buff);
+    }
+
+    return *this;
+  }
+
+  Stream &operator<<(const char *str) { return write(str, strlen(str)); }
+
+  Stream &operator<<(const std::string &str) {
+    return write(str.data(), str.size());
+  }
+
+  Stream &operator<<(std::string_view str) {
+    return write(str.data(), str.size());
+  }
+
+  Stream &resetColor() {
+    if (hasColors()) {
+      write("\033[0m", 4);
+    }
+    return *this;
+  }
+
+  template <typename T>
+  std::enable_if_t<std::is_arithmetic_v<T>, Stream &> operator<<(T val) {
+    char
+        buff[(std::is_floating_point_v<T> ? std::numeric_limits<T>::max_digits10
+                                          : std::numeric_limits<T>::digits10) +
+             0x20];
+
+    auto result = std::to_chars(buff, buff + sizeof(buff), val);
+    if (result.ec == std::errc()) {
+      write(buff, result.ptr - buff);
+    }
+
+    return *this;
+  }
+
+  Stream &changeColor(Color col, bool bold = false, bool bg = false) {
+    if (hasColors()) {
+      int code = int(col);
+
+      if (bg) {
+        code += 10;
+      }
+
+      *this << "\033[";
+      if (bold)
+        *this << "1;";
+      *this << code << "m";
+    }
+    return *this;
+  }
+
+  Stream &operator<<(Color col) { return changeColor(col); }
+};
+
+/// @brief Standard FILE* stream.
+class SFStream : public Stream {
+  FILE *file;
+  bool close;
+
+  void internalWrite(const BufferChar *ptr, size_t size) override {
+    if (file)
+      fwrite(ptr, 1, size, file);
+  }
+
+  void internalFlush() override {
+    if (file)
+      fflush(file);
+  }
+
+public:
+  /// @brief Opens a new stream to a cstdio file.
+  /// @param f Stream to stream to.
+  /// @param closeFile whether or not this stream should take ownership.
+  /// @param bufferSize Set to 0 because most cstdio files already have one.
+  SFStream(FILE *f, bool closeFile, size_t bufferSize = 0)
+      : Stream(bufferSize), file(f), close(closeFile) {}
+
+  ~SFStream() override {
+    setNoBuffer();
+    if (close)
+      fclose(file);
+  }
+};
+
+extern Stream &err();
+extern Stream &out();
+
+} // namespace zap


### PR DESCRIPTION
Custom stream in `utils/stream.hpp/cpp`.
Also changed driver's reporting to use the new stream class.