### PR TITLE
[refactor] Move to a hash map for the driver args.

### DIFF
--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -32,14 +32,14 @@ namespace {
 
 bool emitRequestedTextOutputs(driver &drv, sema::BoundRootNode &node,
                               const std::filesystem::path &base_output_path) {
-  bool direct_output = !drv.is_implicit_output() &&
-                       (drv.emits_llvm_text() != drv.emits_zir());
+  bool direct_output =
+      !drv.is_implicit_output() && (drv.emits_llvm_text() != drv.emits_zir());
 
   if (drv.emits_zir()) {
     auto zir_path = direct_output
                         ? base_output_path
-                        : std::filesystem::path(base_output_path).replace_extension(
-                              driver::format_fileextension(
+                        : std::filesystem::path(base_output_path)
+                              .replace_extension(driver::format_fileextension(
                                   driver::output_type::ZIR));
     std::ofstream zir_output(zir_path, std::ios::binary);
     if (!zir_output) {
@@ -53,11 +53,11 @@ bool emitRequestedTextOutputs(driver &drv, sema::BoundRootNode &node,
   }
 
   if (drv.emits_llvm_text()) {
-    auto llvm_path =
-        direct_output
-            ? base_output_path
-            : std::filesystem::path(base_output_path).replace_extension(
-                  driver::format_fileextension(driver::output_type::TEXT_LLVM));
+    auto llvm_path = direct_output
+                         ? base_output_path
+                         : std::filesystem::path(base_output_path)
+                               .replace_extension(driver::format_fileextension(
+                                   driver::output_type::TEXT_LLVM));
     std::ofstream llvm_output(llvm_path, std::ios::binary);
     if (!llvm_output) {
       driver::reportError("couldn't open the provided file: ", llvm_path,
@@ -74,8 +74,8 @@ bool emitRequestedTextOutputs(driver &drv, sema::BoundRootNode &node,
 
 std::filesystem::path g_executable_path;
 
-std::optional<std::filesystem::path> currentExecutablePath(
-    const std::filesystem::path &argv0Hint) {
+std::optional<std::filesystem::path>
+currentExecutablePath(const std::filesystem::path &argv0Hint) {
   std::error_code ec;
   auto procPath = std::filesystem::read_symlink("/proc/self/exe", ec);
   if (!ec && !procPath.empty()) {
@@ -136,13 +136,16 @@ std::string stripSourceExtension(const std::filesystem::path &path) {
   return normalized;
 }
 
-std::string computeLogicalModulePath(const std::filesystem::path &canonicalPath) {
-  auto stdRoot = std::filesystem::weakly_canonical(stdlibRootPath(g_executable_path));
-  auto cwdRoot = std::filesystem::weakly_canonical(std::filesystem::current_path());
+std::string
+computeLogicalModulePath(const std::filesystem::path &canonicalPath) {
+  auto stdRoot =
+      std::filesystem::weakly_canonical(stdlibRootPath(g_executable_path));
+  auto cwdRoot =
+      std::filesystem::weakly_canonical(std::filesystem::current_path());
 
   auto buildRelative = [&](const std::filesystem::path &root,
-                           const std::string &prefix = "")
-      -> std::optional<std::string> {
+                           const std::string &prefix =
+                               "") -> std::optional<std::string> {
     auto rootText = root.generic_string();
     auto pathText = canonicalPath.generic_string();
     if (pathText == rootText || pathText.rfind(rootText + "/", 0) != 0) {
@@ -200,7 +203,8 @@ bool resolveImportTargets(const std::filesystem::path &modulePath,
   resolvedPath = resolvedPath.lexically_normal();
 
   auto tryFile = [&](const std::filesystem::path &path) -> bool {
-    if (std::filesystem::exists(path) && std::filesystem::is_regular_file(path)) {
+    if (std::filesystem::exists(path) &&
+        std::filesystem::is_regular_file(path)) {
       targets.push_back(std::filesystem::weakly_canonical(path));
       return true;
     }
@@ -211,13 +215,15 @@ bool resolveImportTargets(const std::filesystem::path &modulePath,
     return false;
   }
 
-  if (resolvedPath.extension() != ".zp" && tryFile(resolvedPath.string() + ".zp")) {
+  if (resolvedPath.extension() != ".zp" &&
+      tryFile(resolvedPath.string() + ".zp")) {
     return false;
   }
 
   if (std::filesystem::exists(resolvedPath) &&
       std::filesystem::is_directory(resolvedPath)) {
-    for (const auto &entry : std::filesystem::directory_iterator(resolvedPath)) {
+    for (const auto &entry :
+         std::filesystem::directory_iterator(resolvedPath)) {
       if (!entry.is_regular_file()) {
         continue;
       }
@@ -390,105 +396,211 @@ bool compileLoadedModules(driver &drv, const std::filesystem::path &entryPath) {
   return false;
 }
 
-bool driver::parseArgs(int argc, char **argv) {
-  std::vector<std::string_view> args;
-  for (int i = 1; i < argc; ++i) {
-    args.emplace_back(argv[i]);
+static inline void printhelp() {
+  out() << "Usage: zapc [options] <file>\n"
+           "Options:\n";
+#define ZAP_FLAG(ID, STR, MSG, ...)                                            \
+  out() << "  " STR;                                                           \
+  if constexpr ((2 + (sizeof(STR) - 1)) >= 18) {                               \
+    (out() << '\n').indent(18) << MSG;                                         \
+  } else {                                                                     \
+    out().indent(18 - ((sizeof(STR) - 1) + 2)) << MSG "\n";                    \
   }
-  linker_args.clear();
+#include "../driver/flags.inc"
+#undef ZAP_FLAG
+}
 
-  bool emit_llvm = false;
-  bool emit_zir = false;
-  bool emit_s = false;
-  bool nolink = false;
-  std::string_view output_str = "a.out";
-  implicit_output = true;
-  inc_stdlib = true;
-  allow_unsafe = false;
-  emit_llvm_text = false;
-  emit_zir_text = false;
-  optimization_level = 0;
+enum class ArgTypes : unsigned {
+#define ZAP_FLAG(ID, ...) ID,
+#include "../driver/flags.inc"
+#undef ZAP_FLAG
+  ARGS_END
+};
 
-  for (size_t i = 0; i < args.size(); ++i) {
-    auto arg = args[i];
+class ArgConf {
+public:
+  enum class ArgKind { Flag, Joined, Separate, JoinedSeparate };
 
-    if (arg == "--help") {
-      out()
-          << "Zap Compiler [options] <file>\n"
-          << "Zap Compiler\n\n"
-          << "Options:\n"
-          << "  --help          Display available options\n"
-          << "  --version       Print version information\n"
-          << "  -o <file>       Write output to <file>\n"
-          << "  -nostdlib       Stops the linker from linking the zap stdlib\n"
-          << "  -c              Compile and assemble but not link\n"
-          << "  -S              Compile only no assembling or linking\n"
-          << "  -emit-llvm      Emit LLVM IR instead of final output\n"
-          << "  -emit-zir       Emit ZIR instead of final output\n"
-          << "  --allow-unsafe  Enable unsafe blocks, unsafe functions, and raw pointers\n"
-          << "  -l<name>        Link with library <name> (forwarded to system linker)\n"
-          << "  -L<dir>         Add <dir> to library search path (forwarded to linker)\n"
-          << "  -l <name>       Same as -l<name>\n"
-          << "  -L <dir>        Same as -L<dir>\n"
-          << "  -O, -O0..-O3    Set optimization level (default: -O0)\n"
-          << "  -O00..-O03      Alias for -O0..-O3\n";
-      return false;
-    } else if (arg == "--version") {
-      out() << "Zap Compiler v" << zap::ZAP_VERSION << '\n';
-      return false;
-    } else if (arg == "-o") {
-      if (i + 1 < args.size()) {
-        output_str = args[++i];
-        implicit_output = false;
-      } else {
-        reportError("argument to '-o' is missing");
-        return false;
-      }
-    } else if (arg.substr(0, 2) == "-o") {
-      output_str = arg.substr(2);
-      implicit_output = false;
-    } else if (arg == "-nostdlib") {
-      inc_stdlib = false;
-    } else if (arg == "-c") {
-      nolink = true;
-    } else if (arg == "-S") {
-      emit_s = true;
-    } else if (arg == "-emit-llvm") {
-      emit_llvm = true;
-    } else if (arg == "-emit-zir") {
-      emit_zir = true;
-    } else if (arg == "--allow-unsafe") {
-      allow_unsafe = true;
-    } else if (arg == "-O") {
-      optimization_level = 2;
-    } else if (arg.size() == 3 && arg.substr(0, 2) == "-O" &&
-               arg[2] >= '0' && arg[2] <= '3') {
-      optimization_level = static_cast<int>(arg[2] - '0');
-    } else if (arg.size() == 4 && arg.substr(0, 2) == "-O" &&
-               arg[2] == '0' && arg[3] >= '0' && arg[3] <= '3') {
-      optimization_level = static_cast<int>(arg[3] - '0');
-    } else if (arg.substr(0, 2) == "-O") {
-      reportError("invalid optimization level: ", arg,
-                  " (expected -O, -O0..-O3, or -O00..-O03)");
-      return false;
-    } else if (arg == "-l" || arg == "-L") {
-      if (i + 1 < args.size()) {
-        linker_args.emplace_back(std::string(arg));
-        linker_args.emplace_back(std::string(args[++i]));
-      } else {
-        reportError("argument to '", arg, "' is missing");
-        return false;
-      }
-    } else if (arg.size() > 2 && arg.substr(0, 2) == "-l") {
-      linker_args.emplace_back(std::string(arg));
-    } else if (arg.size() > 2 && arg.substr(0, 2) == "-L") {
-      linker_args.emplace_back(std::string(arg));
-    } else if (arg.substr(0, 1) == "-") {
-      reportError("unknown argument: ", arg);
-      return false;
-    } else {
-      inputs.emplace_back(std::string(arg));
+private:
+  ArgKind _kind;
+  ArgTypes _type;
+
+public:
+  ArgConf(ArgKind kind, ArgTypes type) noexcept : _kind(kind), _type(type) {}
+
+  ArgKind getKind() const noexcept { return _kind; }
+
+  ArgTypes getType() const noexcept { return _type; }
+};
+
+/// Ideally use a specialized string map.
+const std::unordered_map<std::string_view, ArgConf> arg_map = {{
+#define ZAP_FLAG(ID, STR, MSG, KIND, ...)                                      \
+  {STR, ArgConf(ArgConf::ArgKind::KIND, ArgTypes::ID)},
+#include "../driver/flags.inc"
+#undef ZAP_FLAG
+}};
+
+struct ArgVal {
+  std::string_view original;
+  std::string_view optional;
+  ArgTypes type;
+
+  bool valid() const noexcept { return original.size(); }
+
+  ArgVal(std::string_view og, std::string_view opt, ArgTypes t) noexcept
+      : original(og), optional(opt), type(t) {}
+};
+
+class ArgHolder {
+  uint16_t _posArray[(unsigned)ArgTypes::ARGS_END]{};
+  uint16_t _countArray[(unsigned)ArgTypes::ARGS_END]{};
+  const std::vector<ArgVal> &_args;
+
+public:
+  ArgHolder(const std::vector<ArgVal> &args) : _args(args) {
+    unsigned pos = 0;
+    for (const ArgVal &arg : _args) {
+      unsigned idx = (unsigned)arg.type;
+      _posArray[idx] = pos++;
+      _countArray[idx]++;
     }
+  }
+
+  unsigned count(ArgTypes t) const noexcept { return _countArray[(unsigned)t]; }
+
+  bool has(ArgTypes t) const noexcept { return count(t); }
+
+  const ArgVal *get(ArgTypes argT) const noexcept {
+    if (!has(argT))
+      return nullptr;
+    return &_args[_posArray[(unsigned)argT]];
+  }
+
+  std::vector<const ArgVal *> getAll(ArgTypes argT) const noexcept {
+    if (!has(argT))
+      return {};
+    std::vector<const ArgVal *> vec;
+    for (const ArgVal &arg : _args) {
+      if (arg.type == argT)
+        vec.emplace_back(&arg);
+    }
+    return vec;
+  }
+};
+
+static inline void printversion() {
+  out() << "Zap Compiler v" << zap::ZAP_VERSION << '\n';
+}
+
+bool driver::parseArgs(int argc, char **argv) {
+  bool err = false;
+  std::vector<ArgVal> argsvec;
+
+  for (int i = 1; i < argc; i++) {
+    std::string_view original(argv[i]);
+
+    if (original[0] == '-') {
+      if (auto it = arg_map.find(original); it != arg_map.end()) {
+        const ArgConf &conf = it->second;
+
+        if (conf.getKind() == ArgConf::ArgKind::Flag) {
+          argsvec.emplace_back(original, std::string_view(), conf.getType());
+        } else {
+          if (i + 1 == argc) {
+            reportError("missing value for flag '", it->first, "'");
+            err = true;
+            break;
+          }
+          argsvec.emplace_back(original, argv[i + 1], conf.getType());
+          i++;
+        }
+      } else {
+        const ArgConf *maybeConf = nullptr;
+        size_t offset = 0;
+#define ZAP_FLAG(ID, STR, MSG, KIND, ...)                                      \
+  if constexpr (ArgConf::ArgKind::KIND == ArgConf::ArgKind::Joined ||          \
+                ArgConf::ArgKind::KIND == ArgConf::ArgKind::JoinedSeparate) {  \
+    if (original.size() >= (sizeof(STR) - 1)) {                                \
+      auto it = arg_map.find(original.substr(0, (sizeof(STR) - 1)));           \
+      if (it != arg_map.end()) {                                               \
+        maybeConf = &it->second;                                               \
+        offset = sizeof(STR) - 1;                                              \
+        goto match_found;                                                      \
+      }                                                                        \
+    }                                                                          \
+  }
+#include "../driver/flags.inc"
+#undef ZAP_FLAG
+        reportError("unknown flag '", original, "' encountered");
+        err = true;
+      match_found:
+        argsvec.emplace_back(original, original.substr(offset),
+                             maybeConf->getType());
+      }
+    } else {
+      inputs.emplace_back(original);
+    }
+  }
+
+  if (err) {
+    return false;
+  }
+
+  ArgHolder args(argsvec);
+
+  if (args.has(ArgTypes::Help)) {
+    printhelp();
+    return false;
+  }
+
+  if (args.has(ArgTypes::Version)) {
+    printversion();
+    return false;
+  }
+
+  implicit_output = args.has(ArgTypes::Output);
+  inc_stdlib = !args.has(ArgTypes::NoStdlib);
+  allow_unsafe = args.has(ArgTypes::AllowUnsafe);
+
+  bool emit_s = args.has(ArgTypes::CompileOnlyS);
+  bool nolink = args.has(ArgTypes::CompileOnly);
+  bool emit_llvm = args.has(ArgTypes::EmitLLVM);
+  bool emit_zir = args.has(ArgTypes::EmitZIR);
+
+  if (args.has(ArgTypes::OptLevel)) {
+    std::string_view optL = args.get(ArgTypes::OptLevel)->optional;
+
+    if (optL == "0") {
+      optimization_level = 0;
+    } else if (optL == "1") {
+      optimization_level = 1;
+    } else if (optL == "2") {
+      optimization_level = 2;
+    } else if (optL == "3") {
+      optimization_level = 3;
+    } else {
+      reportError("unknown optimization value '", optL, "' encountered");
+      err = true;
+    }
+  } else
+    optimization_level = 0;
+
+  if (err)
+    return false;
+
+  for (const ArgVal *arg : args.getAll(ArgTypes::LinkDir)) {
+    std::string val = "-L";
+    val += arg->optional;
+
+    linker_args.emplace_back(std::move(val));
+  }
+
+  for (const ArgVal *arg : args.getAll(ArgTypes::LinkLib)) {
+    std::string val = "-l";
+    val += arg->optional;
+
+    linker_args.emplace_back(std::move(val));
   }
 
   if (emit_s) {
@@ -511,7 +623,8 @@ bool driver::parseArgs(int argc, char **argv) {
     return false;
   }
 
-  output = std::filesystem::path(output_str);
+  output = args.has(ArgTypes::Output) ? args.get(ArgTypes::Output)->optional
+                                      : "a.out";
 
   if (!inputs.empty()) {
     return true;
@@ -522,7 +635,7 @@ bool driver::parseArgs(int argc, char **argv) {
 }
 
 bool driver::splitInputs() {
-  for (const std::string &input : get_inputs()) {
+  for (const std::string_view &input : get_inputs()) {
     std::filesystem::path input_path = input;
     std::string ext = input_path.extension().string();
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
@@ -695,7 +808,7 @@ bool driver::compileSourceFile(const std::string &source,
       return true;
     }
   } else if (out_type == output_type::ASM) {
-      return true; // TODO: Implement assembly emission.
+    return true; // TODO: Implement assembly emission.
   } else {
     return true;
   }

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -56,7 +56,9 @@ public:
 
   /// @brief Returns the unsplit input files vector.
   /// @return Const reference to the input files vector.
-  const std::vector<std::string> &get_inputs() const noexcept { return inputs; }
+  const std::vector<std::string_view> &get_inputs() const noexcept {
+    return inputs;
+  }
 
   /// @brief Returns the paths to the source files.
   /// @return Const reference to the source files vector.
@@ -105,16 +107,7 @@ public:
   /// This should change as the compiler evolves, ideally all of the below
   /// should be true.
   bool format_supported() const noexcept {
-    switch (out_type) {
-    case output_type::EXEC:
-    case output_type::OBJECT:
-    case output_type::ASM:
-    case output_type::TEXT_LLVM:
-    case output_type::LLVM:
-    case output_type::ZIR:
-      return true;
-    }
-    return false;
+    return true; // Condition is always true.
   }
 
   /// @brief Returns a file extension based on the file format given.
@@ -183,21 +176,22 @@ private:
   friend bool compileLoadedModules(driver &drv,
                                    const std::filesystem::path &entryPath);
 
-  std::vector<std::string> inputs;            ///< A vector of input files.
+  std::vector<std::string_view> inputs;       ///< A vector of input files.
   std::vector<std::filesystem::path> sources; ///< A vector of .zp files.
   std::vector<std::filesystem::path> objects; ///< A vector of .o files.
   std::vector<std::filesystem::path>
       cleanups;                 ///< A vector of files that need to be deleted.
   std::filesystem::path output; ///< Output file.
   output_type out_type =
-      driver::output_type::EXEC; ///< Output type, default executable.
-  bool implicit_output;          ///< Was the output implicit or explicit.
-  bool inc_stdlib;               ///< Include the zap stdlib.o or not.
-  bool allow_unsafe = false;     ///< Allow unsafe language features.
-  bool emit_llvm_text = false;   ///< Emit textual LLVM IR.
-  bool emit_zir_text = false;    ///< Emit textual ZIR.
-  int optimization_level = 0;    ///< Optimization level (0-3).
-  std::vector<std::string> linker_args; ///< Extra linker arguments (e.g. -lSDL2, -L/path).
+      driver::output_type::EXEC;  ///< Output type, default executable.
+  bool implicit_output;           ///< Was the output implicit or explicit.
+  bool inc_stdlib;                ///< Include the zap stdlib.o or not.
+  bool allow_unsafe = false;      ///< Allow unsafe language features.
+  bool emit_llvm_text = false;    ///< Emit textual LLVM IR.
+  bool emit_zir_text = false;     ///< Emit textual ZIR.
+  uint8_t optimization_level = 0; ///< Optimization level (0-3).
+  std::vector<std::string>
+      linker_args; ///< Extra linker arguments (e.g. -lSDL2, -L/path).
   std::filesystem::path executable_path; ///< Path to the running executable.
 
   /// @brief Used internally by the compile() function.

--- a/src/driver/flags.inc
+++ b/src/driver/flags.inc
@@ -1,0 +1,54 @@
+/// This file includes the flags for the zapc driver.
+
+#ifndef ZAP_FLAG
+#define ZAP_FLAG(...)
+#endif
+
+/// The macro itself follows a simple format:
+/// ZAP_FLAG(
+///   ID          /* Name of the Enum                               */
+///   Flag        /* The flag's string                              */
+///   HelpMessage /* The message that displays when --help is used. */
+///   Kind        /* Kind of the arg (Flag, Joined, etc..)          */
+/// )
+
+// --help
+ZAP_FLAG(Help, "--help", "Displays available options.", Flag)
+
+// --version
+ZAP_FLAG(Version, "--version", "Prints out the version information.", Flag)
+
+// -o
+ZAP_FLAG(Output, "-o", "Sets the output file.", JoinedSeparate)
+
+// -nostdlib
+ZAP_FLAG(NoStdlib, "-nostdlib",
+         "Stops the linker from linking the standard library.", Flag)
+
+// -c
+ZAP_FLAG(CompileOnly, "-c", "Compile and assemble but not link.", Flag)
+
+// -S
+ZAP_FLAG(CompileOnlyS, "-S", "Compile only no assemble or link.", Flag)
+
+// -emit-llvm
+ZAP_FLAG(EmitLLVM, "-emit-llvm", "Emit LLVM IR as the output format.", Flag)
+
+// -emit-zir
+ZAP_FLAG(EmitZIR, "-emit-zir", "Emit ZIR as the output format.", Flag)
+
+// --allow-unsafe
+ZAP_FLAG(AllowUnsafe, "--allow-unsafe",
+         "Enables unsafe blocks, unsafe functions, and raw pointers.", Flag)
+
+// -l
+ZAP_FLAG(LinkLib, "-l", "Link with library <name> (forwarded to the linker).",
+         JoinedSeparate)
+
+// -L
+ZAP_FLAG(LinkDir, "-L",
+         "Add <dir> to library search path (forwarded to the linker).",
+         JoinedSeparate)
+
+// -O
+ZAP_FLAG(OptLevel, "-O", "Set optimization level (default: -O0).", Joined)

--- a/src/utils/stream.cpp
+++ b/src/utils/stream.cpp
@@ -1,7 +1,7 @@
 #include "utils/stream.hpp"
 #include <algorithm>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
 
 #if defined(__unix__) || defined(__APPLE__)
 #include <unistd.h>
@@ -110,6 +110,17 @@ Stream &err() {
 Stream &out() {
   static StdoutStream stdoutStream(stdout, false);
   return stdoutStream;
+}
+
+Stream &Stream::indent(unsigned n) {
+  constexpr const char space_buffer[0x10] = {' ', ' ', ' ', ' ', ' ', ' ',
+                                             ' ', ' ', ' ', ' ', ' ', ' ',
+                                             ' ', ' ', ' ', ' '};
+  while (n > sizeof(space_buffer)) {
+    write(space_buffer, sizeof(space_buffer));
+    n -= sizeof(space_buffer);
+  }
+  return write(space_buffer, n);
 }
 
 /// This is where it is platform dependent.

--- a/src/utils/stream.hpp
+++ b/src/utils/stream.hpp
@@ -142,6 +142,8 @@ public:
     return *this;
   }
 
+  Stream &indent(unsigned n);
+
   Stream &changeColor(Color col, bool bold = false, bool bg = false) {
     if (hasColors()) {
       int code = int(col);


### PR DESCRIPTION
Moving to a hash map approach and X macros instead of a giant if-else statement is more readable.
Although I do have to admit the `driver.cpp` file can be split into multiple C++ files for readability.