### PR TITLE
[fix] Calling this would cause the stream to call a pure virtual function.

### DIFF
--- a/src/utils/stream.hpp
+++ b/src/utils/stream.hpp
@@ -85,7 +85,7 @@ public:
   /// @brief Returns whether or not this stream supports colors.
   virtual bool hasColors() const { return false; }
 
-  virtual ~Stream() noexcept { setNoBuffer(); }
+  virtual ~Stream() noexcept = default;
 
   Stream &operator<<(std::nullptr_t) { return write("null", 4); }
 


### PR DESCRIPTION
If `SFStream` wouldn't have called `setNoBuffer()` in its destructor this would've caused the program to terminate, as `Stream` calling it would be a pure virtual call.