### PR TITLE
Refactor argument parsing logic into reusable module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOURCES
     src/codegen/llvm_codegen_arc.cpp
     src/codegen/class_arc_emitter.cpp
     src/driver/driver.cpp
+    src/driver/args/argparse.cpp
     src/utils/stream.cpp
 )
 

--- a/src/driver/args/argparse.cpp
+++ b/src/driver/args/argparse.cpp
@@ -1,0 +1,280 @@
+#include "argparse.hpp"
+#include "args.hpp"
+
+#include "../compiler.hpp"
+
+namespace zap {
+
+void printHelp() {
+  out() << "Usage: zapc [options] <file>\n"
+           "Options:\n";
+#define ZAP_FLAG(ID, STR, MSG, ...)                                            \
+  out() << "  " STR;                                                           \
+  if constexpr ((2 + (sizeof(STR) - 1)) >= 18) {                               \
+    (out() << '\n').indent(18) << MSG;                                         \
+  } else {                                                                     \
+    out().indent(18 - ((sizeof(STR) - 1) + 2)) << MSG "\n";                    \
+  }
+#include "flags.inc"
+#undef ZAP_FLAG
+}
+
+void printVersion() { out() << "Zap Compiler v" << ZAP_VERSION << '\n'; }
+
+namespace args {
+
+enum class ArgTypes : unsigned {
+#define ZAP_FLAG(ID, ...) ID,
+#include "flags.inc"
+#undef ZAP_FLAG
+  ARGS_END
+};
+
+class ArgConf {
+public:
+  enum class ArgKind { Flag, Joined, Separate, JoinedSeparate };
+
+private:
+  ArgKind _kind;
+  ArgTypes _type;
+
+public:
+  ArgConf(ArgKind kind, ArgTypes type) noexcept : _kind(kind), _type(type) {}
+
+  ArgKind getKind() const noexcept { return _kind; }
+
+  ArgTypes getType() const noexcept { return _type; }
+};
+
+/// Ideally use a specialized string map.
+const std::unordered_map<std::string_view, ArgConf> arg_map = {{
+#define ZAP_FLAG(ID, STR, MSG, KIND, ...)                                      \
+  {STR, ArgConf(ArgConf::ArgKind::KIND, ArgTypes::ID)},
+#include "flags.inc"
+#undef ZAP_FLAG
+}};
+
+struct ArgVal {
+  std::string_view original;
+  std::string_view optional;
+  ArgTypes type;
+
+  bool valid() const noexcept { return original.size(); }
+
+  ArgVal(std::string_view og, std::string_view opt, ArgTypes t) noexcept
+      : original(og), optional(opt), type(t) {}
+};
+
+class ArgHolder {
+  uint16_t _posArray[(unsigned)ArgTypes::ARGS_END]{};
+  uint16_t _countArray[(unsigned)ArgTypes::ARGS_END]{};
+  const std::vector<ArgVal> &_args;
+
+public:
+  ArgHolder(const std::vector<ArgVal> &args) : _args(args) {
+    unsigned pos = 0;
+    for (const ArgVal &arg : _args) {
+      unsigned idx = (unsigned)arg.type;
+      _posArray[idx] = pos++;
+      _countArray[idx]++;
+    }
+  }
+
+  unsigned count(ArgTypes t) const noexcept { return _countArray[(unsigned)t]; }
+
+  bool has(ArgTypes t) const noexcept { return count(t); }
+
+  const ArgVal *get(ArgTypes argT) const noexcept {
+    if (!has(argT))
+      return nullptr;
+    return &_args[_posArray[(unsigned)argT]];
+  }
+
+  std::vector<const ArgVal *> getAll(ArgTypes argT) const noexcept {
+    if (!has(argT))
+      return {};
+    std::vector<const ArgVal *> vec;
+    for (const ArgVal &arg : _args) {
+      if (arg.type == argT)
+        vec.emplace_back(&arg);
+    }
+    return vec;
+  }
+};
+
+ParseResult parse(const std::vector<std::string_view> &cmdline,
+                  CmdlineArgs &args) {
+  bool ok = true;
+  std::vector<ArgVal> argsvec;
+
+  for (size_t i = 1; i < cmdline.size(); i++) {
+    std::string_view original(cmdline[i]);
+
+    if (original[0] == '-') {
+      if (auto it = arg_map.find(original); it != arg_map.end()) {
+        const ArgConf &conf = it->second;
+
+        if (conf.getKind() == ArgConf::ArgKind::Flag) {
+          argsvec.emplace_back(original, std::string_view(), conf.getType());
+        } else {
+          if (i + 1 == cmdline.size()) {
+            reportError("missing value for flag '", it->first, "'");
+            ok = false;
+            break;
+          }
+          argsvec.emplace_back(original, cmdline[i + 1], conf.getType());
+          i++;
+        }
+      } else {
+        const ArgConf *maybeConf = nullptr;
+        size_t offset = 0;
+#define ZAP_FLAG(ID, STR, MSG, KIND, ...)                                      \
+  if constexpr (ArgConf::ArgKind::KIND == ArgConf::ArgKind::Joined ||          \
+                ArgConf::ArgKind::KIND == ArgConf::ArgKind::JoinedSeparate) {  \
+    if (original.size() >= (sizeof(STR) - 1)) {                                \
+      auto it = arg_map.find(original.substr(0, (sizeof(STR) - 1)));           \
+      if (it != arg_map.end()) {                                               \
+        maybeConf = &it->second;                                               \
+        offset = sizeof(STR) - 1;                                              \
+        goto match_found;                                                      \
+      }                                                                        \
+    }                                                                          \
+  }
+#include "flags.inc"
+#undef ZAP_FLAG
+        reportError("unknown flag '", original, "' encountered");
+        ok = false;
+      match_found:
+        argsvec.emplace_back(original, original.substr(offset),
+                             maybeConf->getType());
+      }
+    } else {
+      args.inputs.emplace_back(original);
+    }
+  }
+
+  if (!ok)
+    return ParseResult::Failed;
+
+  ArgHolder holder(argsvec);
+
+  if (holder.has(ArgTypes::Help)) {
+    printHelp();
+    return ParseResult::SkipCompilation;
+  }
+  if (holder.has(ArgTypes::Version)) {
+    printVersion();
+    return ParseResult::SkipCompilation;
+  }
+
+  args.output.implicit = !holder.has(ArgTypes::Output);
+  args.incStdlib = !holder.has(ArgTypes::NoStdlib);
+  args.incPrelude = !holder.has(ArgTypes::NoPrelude);
+
+  bool emitS = holder.has(ArgTypes::CompileOnlyS);
+  bool compileOnly = holder.has(ArgTypes::CompileOnly);
+  bool emitLLVM = holder.has(ArgTypes::EmitLLVM);
+  bool emitZIR = holder.has(ArgTypes::EmitZIR);
+
+  if (holder.has(ArgTypes::OptLevel)) {
+    std::string_view optL = holder.get(ArgTypes::OptLevel)->optional;
+
+    if (optL == "0") {
+      args.optLevel = OptLevel::O0;
+    } else if (optL == "1") {
+      args.optLevel = OptLevel::O1;
+    } else if (optL == "2") {
+      args.optLevel = OptLevel::O2;
+    } else if (optL == "3") {
+      args.optLevel = OptLevel::O3;
+    } else {
+      reportError("unknown optimization value '", optL, "' encountered");
+      ok = false;
+    }
+  } else
+    args.optLevel = OptLevel::O0;
+
+  if (!ok)
+    return ParseResult::Failed;
+
+  for (const ArgVal *arg : holder.getAll(ArgTypes::LinkDir)) {
+    std::string val = "-L";
+    val += arg->optional;
+
+    args.linkerArgs.emplace_back(std::move(val));
+  }
+
+  for (const ArgVal *arg : holder.getAll(ArgTypes::LinkLib)) {
+    std::string val = "-l";
+    val += arg->optional;
+
+    args.linkerArgs.emplace_back(std::move(val));
+  }
+
+  for (const ArgVal *arg : holder.getAll(ArgTypes::ImportMap)) {
+    std::string_view entry = arg->optional;
+    auto eq = entry.find('=');
+    if (eq == std::string_view::npos) {
+      reportError("--import-map requires format @alias=path, got: ", entry);
+      ok = false;
+      continue;
+    }
+    args.importMap[std::string(entry.substr(0, eq))] =
+        std::string(entry.substr(eq + 1));
+  }
+
+  if (!ok)
+    return ParseResult::Failed;
+
+  if (emitS) {
+    if (!emitLLVM && !emitZIR)
+      args.output.type = OutputType::ASM;
+  }
+
+  if (args.output.type == OutputType::EXEC) {
+    if (compileOnly) {
+      args.output.type = OutputType::OBJECT;
+    }
+  }
+
+  if ((emitLLVM || emitZIR) && !args.output.implicit && (emitLLVM == emitZIR)) {
+    reportError("cannot use -o when emitting multiple text outputs");
+    return ParseResult::Failed;
+  }
+
+  args.output.path = holder.has(ArgTypes::Output)
+                         ? holder.get(ArgTypes::Output)->optional
+                         : "a.out";
+
+  if (args.inputs.empty()) {
+    reportError("no input files");
+    return ParseResult::Failed;
+  }
+
+  return ParseResult::Success;
+}
+
+ParseResult parse(int argc, char **argv, CmdlineArgs &args) {
+  std::vector<std::string_view> views;
+  views.reserve(argc);
+
+  for (int i = 0; i < argc; ++i) {
+    views.emplace_back(argv[i]);
+  }
+
+  return parse(views, args);
+}
+
+ParseResult parse(const std::vector<std::string> &argv, CmdlineArgs &args) {
+  std::vector<std::string_view> views;
+  views.reserve(argv.size());
+
+  for (const auto &arg : argv) {
+    views.emplace_back(arg);
+  }
+
+  return parse(views, args);
+}
+
+} // namespace args
+} // namespace zap

--- a/src/driver/args/argparse.hpp
+++ b/src/driver/args/argparse.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "driver/args/args.hpp"
+#include "utils/stream.hpp"
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace zap {
+
+template <typename... TArgs> void reportError(TArgs &&...args) {
+  ((err() << "zapc: ").changeColor(Color::RED, true) << "error: ").resetColor();
+  (err() << ... << args);
+  err() << '\n';
+}
+
+void printHelp();
+void printVersion();
+
+namespace args {
+
+enum class ParseResult {
+  Success,
+  Failed,
+  SkipCompilation,
+};
+
+/// @brief Parses command line arguments from provided argc & argv
+/// @return Success on success (no way), Failed on error, SkipCompilation if
+/// help/version was printed.
+ParseResult parse(int argc, char **argv, CmdlineArgs &args);
+
+/// @brief Parses command line arguments from provided vector of string views
+/// @return Success on success, Failed on error, SkipCompilation if help/version
+/// was printed.
+ParseResult parse(const std::vector<std::string_view> &cmdline,
+                  CmdlineArgs &args);
+
+/// @brief Parses command line arguments from provided vector of strings
+/// @return Success on success, Failed on error, SkipCompilation if help/version
+/// was printed.
+ParseResult parse(const std::vector<std::string> &argv, CmdlineArgs &args);
+
+} // namespace args
+} // namespace zap

--- a/src/driver/args/args.hpp
+++ b/src/driver/args/args.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace zap::args {
+
+using FilePath = std::filesystem::path;
+using ImportMap = std::unordered_map<std::string, std::string>;
+
+/// @brief Different output types that the driver (most likely) supports.
+enum class OutputType : uint8_t {
+  EXEC,      ///< Executable (default), link.
+  OBJECT,    ///< Object file, no linking.
+  ASM,       ///< Assembly.
+  TEXT_LLVM, ///< Textual LLVM IR (-S -emit-llvm).
+  LLVM,      ///< LLVM IR (.bc).
+  ZIR,       ///< ZIR.
+};
+
+/// @brief Optimization level used by the compiler.
+enum class OptLevel : uint8_t {
+  O0, ///< No optimization.
+  O1, ///< Less optimizations.
+  O2, ///< Standard optimization level.
+  O3, ///< More optimizations.
+};
+
+struct CmdlineArgs {
+  std::vector<std::string_view> inputs; ///< A vector of input files.
+  std::vector<FilePath> sources;        ///< A vector of .zp files.
+  std::vector<FilePath> objects;        ///< A vector of .o files.
+
+  struct {
+    FilePath path;                      ///< Output file.
+    OutputType type = OutputType::EXEC; ///< Output type, default executable.
+    bool implicit; ///< Was the output implicit or explicit.
+  } output;
+
+  bool incStdlib;         ///< Include the zap stdlib.o or not.
+  bool incPrelude = true; ///< Include the implicit prelude or not.
+
+  OptLevel optLevel = OptLevel::O1; ///< Optimization level (0-3).
+
+  std::vector<std::string>
+      linkerArgs; ///< Extra linker arguments (e.g. -lSDL2, -L/path).
+
+  ImportMap importMap; ///< Import path aliases (@alias -> path).
+};
+
+} // namespace zap::args

--- a/src/driver/args/flags.inc
+++ b/src/driver/args/flags.inc
@@ -43,7 +43,7 @@ ZAP_FLAG(EmitZIR, "-emit-zir", "Emit ZIR as the output format.", Flag)
 
 // --allow-unsafe
 ZAP_FLAG(AllowUnsafe, "--allow-unsafe",
-         "Enables unsafe blocks, unsafe functions, and raw pointers.", Flag)
+         "Enables unsafe blocks, unsafe functions, and raw pointers. (deprecated, unsafe allowed by default)", Flag)
 
 // -l
 ZAP_FLAG(LinkLib, "-l", "Link with library <name> (forwarded to the linker).",

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -1,7 +1,6 @@
 #include "driver/driver.hpp"
 #include "ast/import_node.hpp"
 #include "codegen/llvm_codegen.hpp"
-#include "driver/compiler.hpp"
 #include "ir/ir_generator.hpp"
 #include "lexer/lexer.hpp"
 #include "parser/parser.hpp"
@@ -44,7 +43,7 @@ bool emitRequestedTextOutputs(driver &drv, sema::BoundRootNode &node,
                         ? base_output_path
                         : std::filesystem::path(base_output_path)
                               .replace_extension(driver::format_fileextension(
-                                  driver::output_type::ZIR));
+                                  args::OutputType::ZIR));
     std::ofstream zir_output(zir_path, std::ios::binary);
     if (!zir_output) {
       driver::reportError("couldn't open the provided file: ", zir_path,
@@ -61,7 +60,7 @@ bool emitRequestedTextOutputs(driver &drv, sema::BoundRootNode &node,
                          ? base_output_path
                          : std::filesystem::path(base_output_path)
                                .replace_extension(driver::format_fileextension(
-                                   driver::output_type::TEXT_LLVM));
+                                   args::OutputType::TEXT_LLVM));
     std::ofstream llvm_output(llvm_path, std::ios::binary);
     if (!llvm_output) {
       driver::reportError("couldn't open the provided file: ", llvm_path,
@@ -389,7 +388,8 @@ bool compileLoadedModules(driver &drv, const std::filesystem::path &entryPath) {
   std::map<std::string, std::unique_ptr<sema::ModuleInfo>> moduleMap;
   std::set<std::string> visiting;
   if (loadModuleGraph(entryPath, moduleMap, visiting,
-                      drv.inc_stdlib && drv.inc_prelude, drv.import_map)) {
+                      drv.cmdArgs.incStdlib && drv.cmdArgs.incPrelude,
+                      drv.cmdArgs.importMap)) {
     return true;
   }
 
@@ -412,7 +412,7 @@ bool compileLoadedModules(driver &drv, const std::filesystem::path &entryPath) {
     modules.push_back(std::move(*module));
   }
 
-  sema::Binder binder(diagnostics, drv.allow_unsafe);
+  sema::Binder binder(diagnostics, true);
   auto boundAst = binder.bind(modules);
   diagnostics.printText(err());
 
@@ -424,10 +424,10 @@ bool compileLoadedModules(driver &drv, const std::filesystem::path &entryPath) {
   if (drv.binary_output()) {
     std::filesystem::path out_path;
 
-    if (drv.get_output_type() == driver::output_type::EXEC) {
+    if (drv.get_output_type() == args::OutputType::EXEC) {
       out_path = entryPath.string() + ".o";
       drv.cleanups.emplace_back(out_path);
-    } else if (drv.get_output_type() == driver::output_type::OBJECT) {
+    } else if (drv.get_output_type() == args::OutputType::OBJECT) {
       if (drv.is_implicit_output()) {
         out_path = entryPath.string() + ".o";
       } else {
@@ -436,18 +436,18 @@ bool compileLoadedModules(driver &drv, const std::filesystem::path &entryPath) {
     }
 
     if (compileObjectFromZIR(*boundAst, out_path.string(),
-                             drv.optimization_level)) {
+                             static_cast<int>(drv.cmdArgs.optLevel))) {
       return true;
     }
 
-    drv.objects.emplace_back(std::move(out_path));
-  } else if (drv.get_output_type() == driver::output_type::ASM) {
+    drv.cmdArgs.objects.emplace_back(std::move(out_path));
+  } else if (drv.get_output_type() == args::OutputType::ASM) {
     std::filesystem::path out_path =
         drv.is_implicit_output() ? entryPath : drv.get_output();
     out_path.replace_extension(
-        driver::format_fileextension(driver::output_type::ASM));
+        driver::format_fileextension(args::OutputType::ASM));
     if (compileAssemblyFromZIR(*boundAst, out_path.string(),
-                               drv.optimization_level)) {
+                               static_cast<int>(drv.cmdArgs.optLevel))) {
       return true;
     }
   } else if (drv.emits_text_output()) {
@@ -463,261 +463,8 @@ bool compileLoadedModules(driver &drv, const std::filesystem::path &entryPath) {
   return false;
 }
 
-static inline void printhelp() {
-  out() << "Usage: zapc [options] <file>\n"
-           "Options:\n";
-#define ZAP_FLAG(ID, STR, MSG, ...)                                            \
-  out() << "  " STR;                                                           \
-  if constexpr ((2 + (sizeof(STR) - 1)) >= 18) {                               \
-    (out() << '\n').indent(18) << MSG;                                         \
-  } else {                                                                     \
-    out().indent(18 - ((sizeof(STR) - 1) + 2)) << MSG "\n";                    \
-  }
-#include "../driver/flags.inc"
-#undef ZAP_FLAG
-}
-
-enum class ArgTypes : unsigned {
-#define ZAP_FLAG(ID, ...) ID,
-#include "../driver/flags.inc"
-#undef ZAP_FLAG
-  ARGS_END
-};
-
-class ArgConf {
-public:
-  enum class ArgKind { Flag, Joined, Separate, JoinedSeparate };
-
-private:
-  ArgKind _kind;
-  ArgTypes _type;
-
-public:
-  ArgConf(ArgKind kind, ArgTypes type) noexcept : _kind(kind), _type(type) {}
-
-  ArgKind getKind() const noexcept { return _kind; }
-
-  ArgTypes getType() const noexcept { return _type; }
-};
-
-/// Ideally use a specialized string map.
-const std::unordered_map<std::string_view, ArgConf> arg_map = {{
-#define ZAP_FLAG(ID, STR, MSG, KIND, ...)                                      \
-  {STR, ArgConf(ArgConf::ArgKind::KIND, ArgTypes::ID)},
-#include "../driver/flags.inc"
-#undef ZAP_FLAG
-}};
-
-struct ArgVal {
-  std::string_view original;
-  std::string_view optional;
-  ArgTypes type;
-
-  bool valid() const noexcept { return original.size(); }
-
-  ArgVal(std::string_view og, std::string_view opt, ArgTypes t) noexcept
-      : original(og), optional(opt), type(t) {}
-};
-
-class ArgHolder {
-  uint16_t _posArray[(unsigned)ArgTypes::ARGS_END]{};
-  uint16_t _countArray[(unsigned)ArgTypes::ARGS_END]{};
-  const std::vector<ArgVal> &_args;
-
-public:
-  ArgHolder(const std::vector<ArgVal> &args) : _args(args) {
-    unsigned pos = 0;
-    for (const ArgVal &arg : _args) {
-      unsigned idx = (unsigned)arg.type;
-      _posArray[idx] = pos++;
-      _countArray[idx]++;
-    }
-  }
-
-  unsigned count(ArgTypes t) const noexcept { return _countArray[(unsigned)t]; }
-
-  bool has(ArgTypes t) const noexcept { return count(t); }
-
-  const ArgVal *get(ArgTypes argT) const noexcept {
-    if (!has(argT))
-      return nullptr;
-    return &_args[_posArray[(unsigned)argT]];
-  }
-
-  std::vector<const ArgVal *> getAll(ArgTypes argT) const noexcept {
-    if (!has(argT))
-      return {};
-    std::vector<const ArgVal *> vec;
-    for (const ArgVal &arg : _args) {
-      if (arg.type == argT)
-        vec.emplace_back(&arg);
-    }
-    return vec;
-  }
-};
-
-static inline void printversion() {
-  out() << "Zap Compiler v" << zap::ZAP_VERSION << '\n';
-}
-
-bool driver::parseArgs(int argc, char **argv) {
-  bool err = false;
-  std::vector<ArgVal> argsvec;
-
-  for (int i = 1; i < argc; i++) {
-    std::string_view original(argv[i]);
-
-    if (original[0] == '-') {
-      if (auto it = arg_map.find(original); it != arg_map.end()) {
-        const ArgConf &conf = it->second;
-
-        if (conf.getKind() == ArgConf::ArgKind::Flag) {
-          argsvec.emplace_back(original, std::string_view(), conf.getType());
-        } else {
-          if (i + 1 == argc) {
-            reportError("missing value for flag '", it->first, "'");
-            err = true;
-            break;
-          }
-          argsvec.emplace_back(original, argv[i + 1], conf.getType());
-          i++;
-        }
-      } else {
-        const ArgConf *maybeConf = nullptr;
-        size_t offset = 0;
-#define ZAP_FLAG(ID, STR, MSG, KIND, ...)                                      \
-  if constexpr (ArgConf::ArgKind::KIND == ArgConf::ArgKind::Joined ||          \
-                ArgConf::ArgKind::KIND == ArgConf::ArgKind::JoinedSeparate) {  \
-    if (original.size() >= (sizeof(STR) - 1)) {                                \
-      auto it = arg_map.find(original.substr(0, (sizeof(STR) - 1)));           \
-      if (it != arg_map.end()) {                                               \
-        maybeConf = &it->second;                                               \
-        offset = sizeof(STR) - 1;                                              \
-        goto match_found;                                                      \
-      }                                                                        \
-    }                                                                          \
-  }
-#include "../driver/flags.inc"
-#undef ZAP_FLAG
-        reportError("unknown flag '", original, "' encountered");
-        err = true;
-      match_found:
-        argsvec.emplace_back(original, original.substr(offset),
-                             maybeConf->getType());
-      }
-    } else {
-      inputs.emplace_back(original);
-    }
-  }
-
-  if (err) {
-    return false;
-  }
-
-  ArgHolder args(argsvec);
-
-  if (args.has(ArgTypes::Help)) {
-    printhelp();
-    return false;
-  }
-
-  if (args.has(ArgTypes::Version)) {
-    printversion();
-    return false;
-  }
-
-  implicit_output = !args.has(ArgTypes::Output);
-  inc_stdlib = !args.has(ArgTypes::NoStdlib);
-  inc_prelude = !args.has(ArgTypes::NoPrelude);
-  // Unsafe features are enabled by default; keep the flag accepted for
-  // backwards compatibility.
-  allow_unsafe = true;
-
-  bool emit_s = args.has(ArgTypes::CompileOnlyS);
-  bool nolink = args.has(ArgTypes::CompileOnly);
-  bool emit_llvm = args.has(ArgTypes::EmitLLVM);
-  bool emit_zir = args.has(ArgTypes::EmitZIR);
-
-  if (args.has(ArgTypes::OptLevel)) {
-    std::string_view optL = args.get(ArgTypes::OptLevel)->optional;
-
-    if (optL == "0") {
-      optimization_level = 0;
-    } else if (optL == "1") {
-      optimization_level = 1;
-    } else if (optL == "2") {
-      optimization_level = 2;
-    } else if (optL == "3") {
-      optimization_level = 3;
-    } else {
-      reportError("unknown optimization value '", optL, "' encountered");
-      err = true;
-    }
-  } else
-    optimization_level = 0;
-
-  if (err)
-    return false;
-
-  for (const ArgVal *arg : args.getAll(ArgTypes::LinkDir)) {
-    std::string val = "-L";
-    val += arg->optional;
-
-    linker_args.emplace_back(std::move(val));
-  }
-
-  for (const ArgVal *arg : args.getAll(ArgTypes::LinkLib)) {
-    std::string val = "-l";
-    val += arg->optional;
-
-    linker_args.emplace_back(std::move(val));
-  }
-
-  for (const ArgVal *arg : args.getAll(ArgTypes::ImportMap)) {
-    std::string_view entry = arg->optional;
-    auto eq = entry.find('=');
-    if (eq == std::string_view::npos) {
-      reportError("--import-map requires format @alias=path, got: ", entry);
-      err = true;
-      continue;
-    }
-    import_map[std::string(entry.substr(0, eq))] =
-        std::string(entry.substr(eq + 1));
-  }
-
-  if (err) {
-    return false;
-  }
-
-  if (emit_s) {
-    if (!emit_llvm && !emit_zir)
-      out_type = output_type::ASM;
-  }
-
-  emit_llvm_text = emit_llvm;
-  emit_zir_text = emit_zir;
-
-  if (out_type == output_type::EXEC) {
-    if (nolink) {
-      out_type = output_type::OBJECT;
-    }
-  }
-
-  if ((emit_llvm_text || emit_zir_text) && !implicit_output &&
-      (emit_llvm_text == emit_zir_text)) {
-    reportError("cannot use -o when emitting multiple text outputs");
-    return false;
-  }
-
-  output = args.has(ArgTypes::Output) ? args.get(ArgTypes::Output)->optional
-                                      : "a.out";
-
-  if (!inputs.empty()) {
-    return true;
-  }
-
-  reportError("no input files");
-  return false;
+args::ParseResult driver::parseArgs(int argc, char **argv) {
+  return args::parse(argc, argv, cmdArgs);
 }
 
 bool driver::splitInputs() {
@@ -727,9 +474,9 @@ bool driver::splitInputs() {
     std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 
     if (ext == ".zp") {
-      sources.emplace_back(std::move(input_path));
+      cmdArgs.sources.emplace_back(std::move(input_path));
     } else if (ext == ".a" || ext == ".o") {
-      objects.emplace_back(std::move(input_path));
+      cmdArgs.objects.emplace_back(std::move(input_path));
     } else {
       reportError("unknown input type: ", input);
       return true;
@@ -740,16 +487,17 @@ bool driver::splitInputs() {
 }
 
 bool driver::verifyOutput() {
-  const zap::driver::output_type &emit_type = get_output_type();
+  const args::OutputType &emit_type = get_output_type();
 
-  bool per_file_emit = emits_text_output() || (emit_type != output_type::EXEC);
+  bool per_file_emit =
+      emits_text_output() || (emit_type != args::OutputType::EXEC);
 
   if (per_file_emit && get_inputs().size() > 1 && !is_implicit_output()) {
     reportError("cannot specify -o with multiple input files");
     return true;
   }
 
-  if (per_file_emit && !objects.empty()) {
+  if (per_file_emit && !cmdArgs.objects.empty()) {
     reportError(
         "cannot use object files or archives with the selected output mode");
     return true;
@@ -775,11 +523,11 @@ bool verifyFile(const std::filesystem::path &input) {
 }
 
 bool driver::verifySources() {
-  for (const std::filesystem::path &input : sources) {
+  for (const std::filesystem::path &input : cmdArgs.sources) {
     if (verifyFile(input))
       return true;
   }
-  for (const std::filesystem::path &input : objects) {
+  for (const std::filesystem::path &input : cmdArgs.objects) {
     if (verifyFile(input))
       return true;
   }
@@ -896,7 +644,7 @@ bool driver::compileSourceFile(const std::string &source,
     return true;
   }
 
-  sema::Binder binder(diagnostics, allow_unsafe);
+  sema::Binder binder(diagnostics, true);
   auto boundAst = binder.bind(*ast);
   diagnostics.printText(err());
 
@@ -908,35 +656,37 @@ bool driver::compileSourceFile(const std::string &source,
   if (binary_output()) {
     std::filesystem::path out_path;
 
-    if (out_type == output_type::EXEC) {
+    if (cmdArgs.output.type == args::OutputType::EXEC) {
       out_path = source_name + ".o";
       cleanups.emplace_back(out_path);
-    } else if (out_type == output_type::OBJECT) {
-      if (implicit_output) {
+    } else if (cmdArgs.output.type == args::OutputType::OBJECT) {
+      if (cmdArgs.output.implicit) {
         out_path = source_name + ".o";
       } else {
-        out_path = output;
+        out_path = cmdArgs.output.path;
       }
     }
 
     if (compileObjectFromZIR(*boundAst, out_path.string(),
-                             optimization_level)) {
+                             static_cast<int>(cmdArgs.optLevel))) {
       return true;
     }
 
-    objects.emplace_back(std::move(out_path));
-  } else if (out_type == output_type::ASM) {
-    std::filesystem::path out_path =
-        implicit_output ? std::filesystem::path(source_name) : output;
+    cmdArgs.objects.emplace_back(std::move(out_path));
+  } else if (cmdArgs.output.type == args::OutputType::ASM) {
+    std::filesystem::path out_path = cmdArgs.output.implicit
+                                         ? std::filesystem::path(source_name)
+                                         : cmdArgs.output.path;
     out_path.replace_extension(
-        driver::format_fileextension(driver::output_type::ASM));
+        driver::format_fileextension(args::OutputType::ASM));
     if (compileAssemblyFromZIR(*boundAst, out_path.string(),
-                               optimization_level)) {
+                               static_cast<int>(cmdArgs.optLevel))) {
       return true;
     }
   } else if (emits_text_output()) {
-    std::filesystem::path out_path =
-        implicit_output ? std::filesystem::path(source_name) : output;
+    std::filesystem::path out_path = cmdArgs.output.implicit
+                                         ? std::filesystem::path(source_name)
+                                         : cmdArgs.output.path;
     if (emitRequestedTextOutputs(*this, *boundAst, out_path)) {
       return true;
     }
@@ -948,7 +698,7 @@ bool driver::compileSourceFile(const std::string &source,
 }
 
 bool driver::compile() {
-  for (const std::filesystem::path &input : sources) {
+  for (const std::filesystem::path &input : cmdArgs.sources) {
     if (compileLoadedModules(*this, input))
       return true;
   }
@@ -962,22 +712,22 @@ bool driver::link() {
 
   std::string cmd = "/usr/bin/cc ";
 
-  if (inc_stdlib) {
+  if (cmdArgs.incStdlib) {
     cmd += stdlibObjectPath(executable_path).string() + " ";
   } else {
     cmd += "-nostdlib ";
   }
 
-  for (const auto &obj : objects) {
+  for (const auto &obj : cmdArgs.objects) {
     cmd += obj.string() + " ";
   }
 
-  for (const auto &arg : linker_args) {
+  for (const auto &arg : cmdArgs.linkerArgs) {
     cmd += arg + " ";
   }
 
   cmd += "-lm ";
-  cmd += "-o " + output.string();
+  cmd += "-o " + cmdArgs.output.path.string();
 
   int res = std::system(cmd.c_str());
   if (res != 0) {

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include "utils/stream.hpp"
 #include <filesystem>
-#include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
+
+#include "args/argparse.hpp"
+#include "args/args.hpp"
+#include "utils/stream.hpp"
 
 namespace zap {
 
@@ -22,8 +25,7 @@ public:
   /// @brief Parses the provided args.
   /// @param argc How many arguments.
   /// @param argv Pointer to the arguments.
-  /// @return True if should continue compiling.
-  bool parseArgs(int argc, char **argv);
+  args::ParseResult parseArgs(int argc, char **argv);
 
   /// @brief Splits inputs based on their file extension.
   /// @return True if an error has occured.
@@ -58,52 +60,51 @@ public:
   /// @brief Returns the unsplit input files vector.
   /// @return Const reference to the input files vector.
   const std::vector<std::string_view> &get_inputs() const noexcept {
-    return inputs;
+    return cmdArgs.inputs;
   }
 
   /// @brief Returns the paths to the source files.
   /// @return Const reference to the source files vector.
   const std::vector<std::filesystem::path> &get_sources() const noexcept {
-    return sources;
+    return cmdArgs.sources;
   }
 
   /// @brief Returns the desired path of the output file.
   /// @return Const reference to the output file path.
-  const std::filesystem::path &get_output() const noexcept { return output; }
+  const std::filesystem::path &get_output() const noexcept {
+    return cmdArgs.output.path;
+  }
 
   /// @brief Returns whether or not the output was explicit (-o) or not.
   /// @return True if was implicit, false if explicit.
-  bool is_implicit_output() const noexcept { return implicit_output; }
-  bool emits_llvm_text() const noexcept { return emit_llvm_text; }
-  bool emits_zir() const noexcept { return emit_zir_text; }
+  bool is_implicit_output() const noexcept { return cmdArgs.output.implicit; }
+  bool emits_llvm_text() const noexcept {
+    return cmdArgs.output.type == args::OutputType::TEXT_LLVM;
+  }
+  bool emits_zir() const noexcept {
+    return cmdArgs.output.type == args::OutputType::ZIR;
+  }
   const std::unordered_map<std::string, std::string> &
   get_import_map() const noexcept {
-    return import_map;
+    return cmdArgs.importMap;
   }
   bool emits_text_output() const noexcept {
-    return emit_llvm_text || emit_zir_text || out_type == output_type::ASM;
+    return cmdArgs.output.type == args::OutputType::TEXT_LLVM ||
+           cmdArgs.output.type == args::OutputType::ZIR ||
+           cmdArgs.output.type == args::OutputType::ASM;
   }
 
-  /// @brief Different output types that the driver (most likely) supports.
-  /// @see parseArgs(int, char**) implementation to see how it chooses the
-  /// output type.
-  enum class output_type : uint8_t {
-    EXEC,      ///< Executable (default), link.
-    OBJECT,    ///< Object file, no linking.
-    ASM,       ///< Assembly.
-    TEXT_LLVM, ///< Textual LLVM IR (-S -emit-llvm).
-    LLVM,      ///< LLVM IR (.bc).
-    ZIR,       ///< ZIR.
-  };
-
   /// @brief Returns the chosen output type.
-  output_type get_output_type() const noexcept { return out_type; }
+  args::OutputType get_output_type() const noexcept {
+    return cmdArgs.output.type;
+  }
 
   /// @brief Returns whether or not the output type needs linking or not.
   /// @return True if needs, false if not.
   /// This shouldn't be used along link() since it already checks it.
   bool needs_linking() const noexcept {
-    return !emits_text_output() && (out_type == output_type::EXEC);
+    return !emits_text_output() &&
+           (cmdArgs.output.type == args::OutputType::EXEC);
   }
 
   /// @brief Returns if the current selected format is supported by this
@@ -117,25 +118,27 @@ public:
 
   /// @brief Returns a file extension based on the file format given.
   /// @return Read-only string.
-  constexpr static const char *format_fileextension(output_type type) noexcept {
+  constexpr static const char *
+  format_fileextension(args::OutputType type) noexcept {
     switch (type) {
     default:
       [[fallthrough]];
-    case output_type::EXEC: // This should depend on the target set, not host.
+    case args::OutputType::EXEC: // This should depend on the target set, not
+                                 // host.
 #ifdef _WIN32
       return ".exe";
 #else
       return "";
 #endif
-    case output_type::OBJECT:
+    case args::OutputType::OBJECT:
       return ".o";
-    case output_type::ASM:
+    case args::OutputType::ASM:
       return ".s";
-    case output_type::TEXT_LLVM:
+    case args::OutputType::TEXT_LLVM:
       return ".ll";
-    case output_type::LLVM:
+    case args::OutputType::LLVM:
       return ".bc";
-    case output_type::ZIR:
+    case args::OutputType::ZIR:
       return ".zir";
     }
   }
@@ -143,31 +146,20 @@ public:
   /// @brief Returns whether the output is binary or text.
   /// @return True if binary, false if text.
   bool binary_output() const noexcept {
-    if (emit_llvm_text || emit_zir_text) {
-      return false;
-    }
-    switch (out_type) {
-    case output_type::EXEC:
+    switch (cmdArgs.output.type) {
+    case args::OutputType::EXEC:
       [[fallthrough]];
-    case output_type::OBJECT:
+    case args::OutputType::OBJECT:
       [[fallthrough]];
-    case output_type::LLVM:
+    case args::OutputType::LLVM:
       return true;
-    case output_type::ASM:
-      [[fallthrough]];
-    case output_type::TEXT_LLVM:
-      [[fallthrough]];
-    case output_type::ZIR:
+    default:
       return false;
     }
-    return false;
   }
 
   template <typename... Args> static void reportError(Args &&...args) {
-    ((err() << "zapc: ").changeColor(Color::RED, true) << "error: ")
-        .resetColor();
-    (err() << ... << args);
-    err() << '\n';
+    zap::reportError(std::forward<Args>(args)...);
   }
 
   template <typename... Args> static void reportWarning(Args &&...args) {
@@ -181,31 +173,15 @@ private:
   friend bool compileLoadedModules(driver &drv,
                                    const std::filesystem::path &entryPath);
 
-  std::vector<std::string_view> inputs;       ///< A vector of input files.
-  std::vector<std::filesystem::path> sources; ///< A vector of .zp files.
-  std::vector<std::filesystem::path> objects; ///< A vector of .o files.
-  std::vector<std::filesystem::path>
-      cleanups;                 ///< A vector of files that need to be deleted.
-  std::filesystem::path output; ///< Output file.
-  output_type out_type =
-      driver::output_type::EXEC;  ///< Output type, default executable.
-  bool implicit_output;           ///< Was the output implicit or explicit.
-  bool inc_stdlib;                ///< Include the zap stdlib.o or not.
-  bool inc_prelude = true;        ///< Include the implicit prelude or not.
-  bool allow_unsafe = true;       ///< Allow unsafe language features.
-  bool emit_llvm_text = false;    ///< Emit textual LLVM IR.
-  bool emit_zir_text = false;     ///< Emit textual ZIR.
-  uint8_t optimization_level = 0; ///< Optimization level (0-3).
-  std::vector<std::string>
-      linker_args; ///< Extra linker arguments (e.g. -lSDL2, -L/path).
-  std::unordered_map<std::string, std::string>
-      import_map; ///< Import path aliases (@alias -> path).
-  std::filesystem::path executable_path; ///< Path to the running executable.
-
   /// @brief Used internally by the compile() function.
   /// @return True if an error has occured.
   bool compileSourceFile(const std::string &source,
                          const std::string &source_name);
+
+  args::CmdlineArgs cmdArgs; ///< Parsed command line arguments.
+  std::vector<std::filesystem::path>
+      cleanups; ///< A vector of files that need to be deleted.
+  std::filesystem::path executable_path; ///< Path to the running executable.
 };
 
 } // namespace zap

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -11,7 +11,7 @@
 
 namespace zap {
 
-/// @brief The class that drives the argument parsing.
+/// @brief Orchestrates and controls the entire compilation process.
 /// Order of the functions that should be called is by how they are defined here
 /// in the header. Meaning that first is parseArgs(int, char**), second is
 /// splitInputs(), third is verifySources(), and so on... Most functions

--- a/src/lsp/lsp-main.cpp
+++ b/src/lsp/lsp-main.cpp
@@ -1,3 +1,4 @@
+#include "driver/args/argparse.hpp"
 #include "lexer/lexer.hpp"
 #include "lsp.hpp"
 #include "parser/parser.hpp"
@@ -197,27 +198,27 @@ bool readSourceFile(const std::filesystem::path &path, std::string &content) {
   return true;
 }
 
-struct LspFlags {
-  bool allowUnsafe = true;
-};
-
-LspFlags readFlagsFromFile(const std::filesystem::path &path) {
-  LspFlags flags;
+zap::args::CmdlineArgs readFlagsFromFile(const std::filesystem::path &path) {
+  zap::args::CmdlineArgs args;
   std::ifstream file(path);
   if (!file) {
-    return flags;
+    return args;
   }
 
-  std::string line;
-  while (std::getline(file, line)) {
-    if (line == "--allow-unsafe") {
-      flags.allowUnsafe = true;
-    }
+  std::vector<std::string> argv;
+  argv.push_back(
+      "zapc"); // TODO: this is pretty ugly but works. Consider refactoring
+               // argument parser to not parse the program path from argv[0].
+  std::string word;
+  while (file >> word) {
+    argv.push_back(word);
   }
-  return flags;
+
+  zap::args::parse(argv, args);
+  return args;
 }
 
-LspFlags findAndReadFlags(std::filesystem::path startPath) {
+zap::args::CmdlineArgs findAndReadFlags(std::filesystem::path startPath) {
   if (std::filesystem::is_regular_file(startPath)) {
     startPath = startPath.parent_path();
   }
@@ -263,13 +264,33 @@ void injectImplicitPreludeImportIfNeeded(sema::ModuleInfo &module) {
 
 bool resolveImportTargets(const std::filesystem::path &modulePath,
                           const ImportNode &importNode,
-                          std::vector<std::filesystem::path> &targets) {
+                          std::vector<std::filesystem::path> &targets,
+                          const zap::args::ImportMap &importMap) {
   std::filesystem::path resolvedPath;
-  if (importNode.path.rfind("std/", 0) == 0) {
-    resolvedPath =
-        stdlibRootPath() / importNode.path.substr(std::string("std/").size());
-  } else {
-    resolvedPath = modulePath.parent_path() / importNode.path;
+  const std::string &importPath = importNode.path;
+
+  // TODO: duplicated logic (see driver.cpp:236 resolveImportTargets)
+  //       this probably should be refactored into
+  //       a shared utility function.
+  bool resolvedViaMap = false;
+  for (const auto &[alias, target] : importMap) {
+    if (importPath.rfind(alias, 0) == 0) {
+      std::string rest = importPath.substr(alias.size());
+      if (!rest.empty() && rest[0] == '/')
+        rest = rest.substr(1);
+      resolvedPath = std::filesystem::path(target) / rest;
+      resolvedViaMap = true;
+      break;
+    }
+  }
+
+  if (!resolvedViaMap) {
+    if (importPath.rfind("std/", 0) == 0) {
+      resolvedPath =
+          stdlibRootPath() / importPath.substr(std::string("std/").size());
+    } else {
+      resolvedPath = modulePath.parent_path() / importPath;
+    }
   }
   resolvedPath = resolvedPath.lexically_normal();
 
@@ -1855,7 +1876,8 @@ class Workspace {
       const std::filesystem::path &modulePath,
       std::map<std::string, std::unique_ptr<sema::ModuleInfo>> &modules,
       std::set<std::string> &visiting, AnalysisResult &result,
-      const std::string &entryUri, bool allowEntryErrors = false) const {
+      const std::string &entryUri, const zap::args::ImportMap &importMap,
+      bool allowEntryErrors = false) const {
     std::filesystem::path canonicalPath =
         std::filesystem::weakly_canonical(modulePath);
     std::string moduleId = canonicalPath.string();
@@ -1924,7 +1946,8 @@ class Workspace {
       }
 
       std::vector<std::filesystem::path> importTargets;
-      if (!resolveImportTargets(canonicalPath, *importNode, importTargets)) {
+      if (!resolveImportTargets(canonicalPath, *importNode, importTargets,
+                                importMap)) {
         continue;
       }
 
@@ -1938,7 +1961,7 @@ class Workspace {
     for (const auto &import : module->imports) {
       for (const auto &targetId : import.targetModuleIds) {
         if (!loadModuleGraph(targetId, modules, visiting, result, entryUri,
-                             allowEntryErrors)) {
+                             importMap, allowEntryErrors)) {
           visiting.erase(moduleId);
           return false;
         }
@@ -2010,10 +2033,13 @@ public:
       return std::nullopt;
     }
 
+    auto flags = findAndReadFlags(docIt->second.path);
+
     ProjectState state;
     std::set<std::string> visiting;
     if (!loadModuleGraph(docIt->second.path, state.moduleMap, visiting,
-                         state.analysis, uri, allowEntryErrors)) {
+                         state.analysis, uri, flags.importMap,
+                         allowEntryErrors)) {
       if (state.analysis.diagnosticsByUri.find(uri) ==
           state.analysis.diagnosticsByUri.end()) {
         state.analysis.diagnosticsByUri[uri] = {};
@@ -2039,10 +2065,12 @@ public:
       return result;
     }
 
+    auto flags = findAndReadFlags(docIt->second.path);
+
     std::map<std::string, std::unique_ptr<sema::ModuleInfo>> moduleMap;
     std::set<std::string> visiting;
     if (!loadModuleGraph(docIt->second.path, moduleMap, visiting, result, uri,
-                         false)) {
+                         flags.importMap, false)) {
       if (result.diagnosticsByUri.find(uri) == result.diagnosticsByUri.end()) {
         result.diagnosticsByUri[uri] = {};
       }
@@ -2072,9 +2100,7 @@ public:
       modules.push_back(std::move(*modulePtr));
     }
 
-    auto flags = findAndReadFlags(docIt->second.path);
-
-    sema::Binder binder(diagnostics, flags.allowUnsafe);
+    sema::Binder binder(diagnostics);
     auto boundAst = binder.bind(modules);
     (void)boundAst;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,13 @@ int main(int argc, char **argv) {
       zapcDriver.setExecutablePath(argv[0]);
     }
 
-    if (!zapcDriver.parseArgs(argc, argv)) {
+    switch (auto res = zapcDriver.parseArgs(argc, argv); res) {
+      using namespace zap::args;
+    case ParseResult::Success:
+      break;
+    case ParseResult::Failed:
+      return 1;
+    case ParseResult::SkipCompilation:
       return 0;
     }
 


### PR DESCRIPTION
This PR refactors command-line argument handling into a dedicated module and reuses it within the LSP, enabling support for import maps in editor tooling.