### PR TITLE
Rewrite some parts of the stdlib in zap

### DIFF
--- a/core/core.zp
+++ b/core/core.zp
@@ -110,3 +110,7 @@ pub fun indexOf(s: noescape StringView,
 
   return -1;
 }
+
+pub unsafe fun getDataPtr(s: noescape StringView) *Char {
+    return s.ptr;
+}

--- a/run_tests.py
+++ b/run_tests.py
@@ -81,6 +81,7 @@ SPECIAL_CASES = {
 
     # Runtime with custom run arguments
     "tests/process_args_test.zp": {"type": "runtime", "exit": 0, "run_args": ["alpha", "beta", "gamma"], "desc": "Process argument access"},
+    "tests/get_env_test.zp": {"type": "runtime", "exit": 0, "env": {"TIP": "#define struct union"}, "desc": "getenv test"},
 
     # Custom compile flags and output check
     "tests/nostdlib_ext_main_object.zp": {
@@ -319,9 +320,9 @@ def discover_tests():
                 # Skip scratch files starting with tmp_
                 if file.startswith("tmp_"):
                     continue
-                    
+
                 file_path = os.path.join(root, file)
-                
+
                 # Rules to determine if it is a standalone test entry point:
                 is_test = False
                 if root == "tests":
@@ -330,10 +331,10 @@ def discover_tests():
                     is_test = True
                 elif file == "main.zp" or file.startswith("main_"):
                     is_test = True
-                    
+
                 if is_test:
                     test_files.append(file_path)
-                    
+
     test_files.sort()
     return test_files
 
@@ -346,18 +347,18 @@ def get_test_config(file_path):
         config = SPECIAL_CASES[key].copy()
         config["file"] = file_path
         return config
-        
+
     # Default fallbacks
     filename = os.path.basename(file_path)
     config = {
         "file": file_path,
         "desc": f"Test {file_path}"
     }
-    
+
     # Check if this filename specifies it is an error or failure test
     # but not a regular test file (ending with _test.zp)
     is_test_suffix = filename.endswith("_test.zp")
-    
+
     # Classify error tests
     if not is_test_suffix and ("error" in filename or "fail" in filename or "outside" in filename):
         config["type"] = "compile"
@@ -371,7 +372,7 @@ def get_test_config(file_path):
     else:
         config["type"] = "runtime"
         config["exit"] = 0
-        
+
     return config
 
 def execute_test(test_item, zapc_path):
@@ -387,9 +388,9 @@ def execute_test(test_item, zapc_path):
     output_patterns = test_item.get("output_patterns", [])
     if "output_pattern" in test_item:
         output_patterns = [test_item["output_pattern"]] + output_patterns
-    
+
     to_cleanup = []
-    
+
     try:
         if test_type == "runtime":
             # Generate a unique binary name per thread to prevent collision
@@ -398,37 +399,40 @@ def execute_test(test_item, zapc_path):
                 "binary_path", f"{file_path}_{tid}.bin"
             ).format(tid=tid)
             to_cleanup.append(bin_path)
-            
+
             # Compile step
             cmd = [zapc_path, file_path] + compile_flags + ["-o", bin_path]
             res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            
+
             if res.returncode != 0:
                 return False, f"Compilation failed with exit code {res.returncode}\nStderr:\n{res.stderr}"
-            
+
             if not os.path.exists(bin_path):
                 return False, f"Compiled binary not found at: {bin_path}"
-                
+
             # Run step
             run_cmd = [bin_path] + run_args
-            res_run = subprocess.run(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            
+            env = os.environ.copy()
+            if "env" in test_item:
+                env.update(test_item["env"])
+            res_run = subprocess.run(run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
+
             if res_run.returncode != expected_exit:
                 return False, f"Runtime failed: expected exit code {expected_exit}, got {res_run.returncode}\nStderr:\n{res_run.stderr}\nStdout:\n{res_run.stdout}"
-                
+
             return True, None
-            
+
         elif test_type == "compile":
             cmd = [zapc_path, file_path] + compile_flags
             if output_file:
                 cmd += ["-o", output_file]
                 to_cleanup.append(output_file)
-                
+
             res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            
+
             if res.returncode != expected_exit:
                 return False, f"Compiler exit code: expected {expected_exit}, got {res.returncode}\nStderr:\n{res.stderr}"
-                
+
             if output_file:
                 if not os.path.exists(output_file):
                     return False, f"Expected output file not found: {output_file}"
@@ -438,48 +442,48 @@ def execute_test(test_item, zapc_path):
                     for output_pattern in output_patterns:
                         if output_pattern not in output_text:
                             return False, f"Expected output pattern '{output_pattern}' not found in {output_file}"
-                    
+
             if stderr_pattern:
                 if stderr_pattern.lower() not in res.stderr.lower():
                     return False, f"Expected warning pattern '{stderr_pattern}' not found in stderr:\n{res.stderr}"
-                    
+
             return True, None
-            
+
         elif test_type == "warning":
             cmd = [zapc_path, file_path] + compile_flags
             res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            
+
             if res.returncode != expected_exit:
                 return False, f"Compiler exit code: expected {expected_exit}, got {res.returncode}\nStderr:\n{res.stderr}"
-                
+
             if stderr_pattern:
                 if stderr_pattern.lower() not in res.stderr.lower():
                     return False, f"Expected warning pattern '{stderr_pattern}' not found in stderr:\n{res.stderr}"
-                    
+
             return True, None
-            
+
         elif test_type == "diagnostic":
             cmd = [zapc_path, file_path] + compile_flags
             res = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
-            
+
             if res.returncode != expected_exit:
                 return False, f"Compiler exit code: expected {expected_exit}, got {res.returncode}\nStderr:\n{res.stderr}"
-                
+
             missing_codes = []
             for code in diagnostics:
                 if code not in res.stderr:
                     missing_codes.append(code)
             if missing_codes:
                 return False, f"Missing diagnostic codes: {', '.join(missing_codes)}\nStderr:\n{res.stderr}"
-                
+
             return True, None
-            
+
         else:
             return False, f"Unknown test type: {test_type}"
-            
+
     except Exception as e:
         return False, f"Exception during test run: {str(e)}"
-        
+
     finally:
         for path in to_cleanup:
             try:
@@ -500,18 +504,18 @@ def build_compiler():
     else:
         res = subprocess.run(["build.bat"], shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         zapc = "./build/zapc.exe"
-        
+
     if res.returncode != 0:
         print(f"{RED}Failed to build the compiler!{NC}")
         if res.stdout:
             print(res.stdout.decode(errors='replace'))
         print(res.stderr.decode(errors='replace'))
         sys.exit(1)
-        
+
     if not os.path.exists(zapc):
         print(f"{RED}Compiler executable not found at {zapc}{NC}")
         sys.exit(1)
-        
+
     print(f"{GREEN}Compiler built successfully!{NC}\n")
     return zapc
 
@@ -526,7 +530,7 @@ def main():
 
     # Step 1: Discover test files
     discovered = discover_tests()
-    
+
     # Generate test suite list
     test_suite = []
     for f in discovered:
@@ -540,7 +544,7 @@ def main():
                     break
             if not matched:
                 continue
-                
+
         test_suite.append(get_test_config(f))
 
     # Add extra compiler validation runs if we are running everything or matching them
@@ -576,12 +580,12 @@ def main():
 
     print("--- Zap Compiler Test Suite ---")
     total_tests = len(test_suite)
-    
+
     # Configure parallel jobs
     num_jobs = args.jobs
     if num_jobs is None:
         num_jobs = max(1, os.cpu_count() - 1)
-        
+
     progress_lock = threading.Lock()
     completed = 0
     passed = 0
@@ -591,9 +595,9 @@ def main():
         nonlocal completed, passed
         desc = test_item.get("desc", test_item["file"])
         file_path = test_item["file"]
-        
+
         ok, err_msg = execute_test(test_item, zapc_path)
-        
+
         with progress_lock:
             completed += 1
             if ok:
@@ -602,21 +606,21 @@ def main():
             else:
                 status_str = f"{RED}FAIL{NC}"
                 failed_details.append((desc, file_path, err_msg))
-                
+
             print(f"[{completed:3d}/{total_tests:3d}] Running {desc} ({file_path})... {status_str}")
 
     start_time = time.time()
-    
+
     # Run tests using thread pool
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_jobs) as executor:
         executor.map(run_wrapper, test_suite)
-        
+
     duration = time.time() - start_time
-    
+
     # Print results
     print("-------------------------------")
     print(f"Results: {passed} / {total_tests} passed (took {duration:.2f} seconds)")
-    
+
     if failed_details:
         print(f"\n{RED}Failed Tests Detail:{NC}")
         for idx, (desc, file_path, err_msg) in enumerate(failed_details, 1):
@@ -626,7 +630,7 @@ def main():
                 indented = "\n".join("   " + line for line in err_msg.splitlines())
                 print(indented)
             print()
-            
+
         print(f"{RED}SOME TESTS FAILED!{NC}")
         sys.exit(1)
     else:

--- a/src/stdlib.c
+++ b/src/stdlib.c
@@ -602,12 +602,6 @@ __attribute__((destructor)) static void zap_arc_shutdown(void) {
   zap_arc_context_release_storage(zap_arc_default_context());
 }
 
-void printInt(long v) { printf("%ld\n", v); }
-
-void printFloat(float v) { printf("%f\n", v); }
-
-void printFloat64(double v) { printf("%f\n", v); }
-
 long zap_sum_variadic(long count, ...) {
   va_list args;
   va_start(args, count);
@@ -617,13 +611,6 @@ long zap_sum_variadic(long count, ...) {
   }
   va_end(args);
   return sum;
-}
-
-void printBool(_Bool v) { printf("%s\n", v ? "true" : "false"); }
-
-void printChar(char v) {
-  putchar(v);
-  putchar('\n');
 }
 
 static char *zap_string_alloc_owned(size_t len);
@@ -682,13 +669,6 @@ static void zap_string_release_ptr(const char *ptr) {
   if (header->refs <= 0) {
     free(header);
   }
-}
-
-void print(zap_string_t s) {
-  if (!s.ptr || s.len <= 0) {
-    return;
-  }
-  fwrite(s.ptr, 1, (size_t)s.len, stdout);
 }
 
 static char *zap_string_to_cstr(zap_string_t s) {
@@ -793,13 +773,6 @@ void __zap_process_set_args(int argc, char **argv) {
   zap_process_argv = argv;
 }
 
-void println(zap_string_t s) {
-  print(s);
-  fputc('\n', stdout);
-}
-
-void zap_flush_stdout(void) { fflush(stdout); }
-
 long zap_printf(zap_string_t format, ...) {
   char *fmt = zap_string_to_cstr(format);
   if (!fmt)
@@ -831,15 +804,6 @@ long zap_printfln(zap_string_t format, ...) {
   if (printf("\n") < 0)
     return -1;
   return written + 1;
-}
-
-void eprintln(zap_string_t s) {
-  if (!s.ptr || s.len <= 0) {
-    fputc('\n', stderr);
-    return;
-  }
-  fwrite(s.ptr, 1, (size_t)s.len, stderr);
-  fputc('\n', stderr);
 }
 
 zap_string_t getln() {

--- a/src/stdlib.c
+++ b/src/stdlib.c
@@ -844,18 +844,6 @@ zap_string_t argv(long i) {
   return zap_string_from_cstr(arg);
 }
 
-zap_string_t zap_process_getenv(zap_string_t name) {
-  char *name_buffer = zap_string_to_cstr(name);
-  if (!name_buffer) {
-    return (zap_string_t){.ptr = NULL, .len = 0};
-  }
-
-  const char *value = getenv(name_buffer);
-  zap_string_t result = zap_string_from_cstr(value);
-  free(name_buffer);
-  return result;
-}
-
 long len(zap_string_t s) { return s.len; }
 
 char at(zap_string_t s, long i) {

--- a/src/stdlib.c
+++ b/src/stdlib.c
@@ -1182,24 +1182,6 @@ long zap_fs_write_file(zap_string_t path, zap_string_t content) {
 
 long zap_fs_last_error() { return zap_fs_last_error_code; }
 
-double zapMathFloor(double x) { return floor(x); }
-double zapMathCeil(double x) { return ceil(x); }
-double zapMathRound(double x) { return round(x); }
-double zapMathTrunc(double x) { return trunc(x); }
-double zapMathPow(double x, double y) { return pow(x, y); }
-double zapMathSqrt(double x) { return sqrt(x); }
-double zapMathSin(double x) { return sin(x); }
-double zapMathCos(double x) { return cos(x); }
-double zapMathTan(double x) { return tan(x); }
-double zapMathAsin(double x) { return asin(x); }
-double zapMathAcos(double x) { return acos(x); }
-double zapMathAtan(double x) { return atan(x); }
-double zapMathAtan2(double y, double x) { return atan2(y, x); }
-double zapMathExp(double x) { return exp(x); }
-double zapMathLog(double x) { return log(x); }
-double zapMathLog10(double x) { return log10(x); }
-double zapMathLog2(double x) { return log2(x); }
-
 long netConnect(zap_string_t host, long port) {
   if (!host.ptr || port <= 0 || port > 65535) {
     zap_net_last_error = EINVAL;

--- a/std/io.zp
+++ b/std/io.zp
@@ -1,16 +1,38 @@
-pub ext fun print(s: String) Void;
-pub ext fun println(s: String) Void;
-pub ext fun printInt(i: Int) Void;
-pub ext fun printFloat(f: Float) Void;
-pub ext fun printFloat64(f: Float64) Void;
-pub ext fun printBool(b: Bool) Void;
-pub ext fun printChar(c: Char) Void;
-pub ext fun eprintln(s: String) Void;
-pub ext fun zap_flush_stdout() Void;
 pub ext fun getln() String;
 pub ext fun printf(format: String, ...) Int;
 pub ext fun printfln(format: String, ...) Int;
 
-pub fun flush() {
-    zap_flush_stdout();
+import "core" { StringView, getDataPtr, len };
+
+alias File = Void;
+ext var stdout: *File;
+ext var stderr: *File;
+
+ext fun fwrite(ptr: *Void, size: UInt, n: UInt, f: *File) UInt;
+ext fun fflush(f: *File) Int32;
+
+pub fun print(str: String) Void {
+    unsafe { fwrite(getDataPtr(str) as *Void, 1, len(str), stdout); }
 }
+pub fun eprint(str: String) Void {
+    unsafe { fwrite(getDataPtr(str) as *Void, 1, len(str), stderr); }
+}
+
+pub fun println(str: String) Void {
+    print(str);
+    print("\n");
+}
+pub fun eprintln(str: String) Void {
+    eprint(str);
+    eprint("\n");
+}
+
+pub fun printInt(v: Int) Void         { printf("%ld\n", v); }
+pub fun printFloat(v: Float) Void     { printf("%f\n", v); }
+pub fun printFloat64(v: Float64) Void { printf("%f\n", v); }
+pub fun printChar(v: Char) Void       { printf("%c\n", v); }
+
+pub fun printBool(v: Bool) Void { printf("%s\n", v ? "true" : "false"); }
+
+pub fun flush() Void  { fflush(stdout); }
+pub fun eflush() Void { fflush(stderr); }

--- a/std/math.zp
+++ b/std/math.zp
@@ -5,23 +5,23 @@ pub const SQRT2: Float64 = 1.41421356237309504880;
 pub const DEG_TO_RAD: Float64 = 0.01745329251994329577;
 pub const RAD_TO_DEG: Float64 = 57.2957795130823208768;
 
-ext fun zapMathSqrt(x: Float64) Float64;
-ext fun zapMathFloor(x: Float64) Float64;
-ext fun zapMathCeil(x: Float64) Float64;
-ext fun zapMathRound(x: Float64) Float64;
-ext fun zapMathTrunc(x: Float64) Float64;
-ext fun zapMathPow(x: Float64, y: Float64) Float64;
-ext fun zapMathSin(x: Float64) Float64;
-ext fun zapMathCos(x: Float64) Float64;
-ext fun zapMathTan(x: Float64) Float64;
-ext fun zapMathAsin(x: Float64) Float64;
-ext fun zapMathAcos(x: Float64) Float64;
-ext fun zapMathAtan(x: Float64) Float64;
-ext fun zapMathAtan2(y: Float64, x: Float64) Float64;
-ext fun zapMathExp(x: Float64) Float64;
-ext fun zapMathLog(x: Float64) Float64;
-ext fun zapMathLog10(x: Float64) Float64;
-ext fun zapMathLog2(x: Float64) Float64;
+pub ext fun sqrt(x: Float64) Float64;
+pub ext fun floor(x: Float64) Float64;
+pub ext fun ceil(x: Float64) Float64;
+pub ext fun round(x: Float64) Float64;
+pub ext fun trunc(x: Float64) Float64;
+pub ext fun pow(x: Float64, y: Float64) Float64;
+pub ext fun sin(x: Float64) Float64;
+pub ext fun cos(x: Float64) Float64;
+pub ext fun tan(x: Float64) Float64;
+pub ext fun asin(x: Float64) Float64;
+pub ext fun acos(x: Float64) Float64;
+pub ext fun atan(x: Float64) Float64;
+pub ext fun atan2(y: Float64, x: Float64) Float64;
+pub ext fun exp(x: Float64) Float64;
+pub ext fun log(x: Float64) Float64;
+pub ext fun log10(x: Float64) Float64;
+pub ext fun log2(x: Float64) Float64;
 
 pub fun abs(x: Int) Int {
     if x < 0 {
@@ -94,74 +94,6 @@ pub fun sign(x: Float64) Float64 {
     if x < 0.0 { return -1.0; }
     if x > 0.0 { return 1.0; }
     return 0.0;
-}
-
-pub fun sqrt(x: Float64) Float64 {
-    return zapMathSqrt(x);
-}
-
-pub fun floor(x: Float64) Float64 {
-    return zapMathFloor(x);
-}
-
-pub fun ceil(x: Float64) Float64 {
-    return zapMathCeil(x);
-}
-
-pub fun round(x: Float64) Float64 {
-     return zapMathRound(x);
-}
-
-pub fun trunc(x: Float64) Float64 {
-    return zapMathTrunc(x);
-}
-
-pub fun pow(base: Float64, exp: Float64) Float64 {
-    return zapMathPow(base, exp);
-}
-
-pub fun exp(x: Float64) Float64 {
-    return zapMathExp(x);
-}
-
-pub fun log(x: Float64) Float64 {
-    return zapMathLog(x);
-}
-
-pub fun log10(x: Float64) Float64 {
-    return zapMathLog10(x);
-}
-
-pub fun log2(x: Float64) Float64 {
-    return zapMathLog2(x);
-}
-
-pub fun sin(x: Float64) Float64 {
-    return zapMathSin(x);
-}
-
-pub fun cos(x: Float64) Float64 {
-    return zapMathCos(x);
-}
-
-pub fun tan(x: Float64) Float64 {
-    return zapMathTan(x);
-}
-
-pub fun asin(x: Float64) Float64 {
-    return zapMathAsin(x);
-}
-
-pub fun acos(x: Float64) Float64 {
-    return zapMathAcos(x);
-}
-
-pub fun atan(x: Float64) Float64 {
-    return zapMathAtan(x);
-}
-
-pub fun atan2(y: Float64, x: Float64) Float64 {
-    return zapMathAtan2(y, x);
 }
 
 pub fun radToDeg(rad: Float64) Float64 {

--- a/std/mem.zp
+++ b/std/mem.zp
@@ -2,3 +2,11 @@ pub ext fun malloc(size: Int) *Void;
 pub ext fun calloc(count: Int, size: Int) *Void;
 pub ext fun realloc(ptr: *Void, size: Int) *Void;
 pub ext fun free(ptr: *Void) Void;
+
+ext fun memcpy (dst: *Void, src: *Void, n: UInt)  *Void;
+ext fun memmove(dst: *Void, src: *Void, n: UInt)  *Void;
+ext fun memset (dst: *Void, ch: Int, count: UInt) *Void;
+
+pub unsafe fun copy(dst: *Void, src: *Void, n: UInt) Void { memcpy(dst, src, n);  }
+pub unsafe fun move(dst: *Void, src: *Void, n: UInt) Void { memmove(dst, src, n); }
+pub unsafe fun fill(dst: *Void, val: UInt8, n: UInt) Void { memset(dst, val, n);  }

--- a/std/process.zp
+++ b/std/process.zp
@@ -1,17 +1,37 @@
-import "std/io" { eprintln };
+import "std/strings";
+
+import "std/mem";
+import "std/io";
 
 pub ext fun exit(code: Int) Void;
 pub ext fun argc() Int;
 pub ext fun argv(i: Int) String;
 pub ext fun exec(cmd: String) Int;
 pub ext fun cwd() String;
-pub ext fun zap_process_getenv(name: String) String;
 
-pub fun getenv(name: String) String {
-  return zap_process_getenv(name);
+ext fun getenv(name: *Char) *Char;
+
+pub fun getEnv(name: String) String {
+  var nameBuf = strings.makeNullTerm(name);
+  if (nameBuf == null) {
+    return "";
+  }
+
+  var value = getenv(nameBuf);
+  if (value == null) {
+    return "";
+  }
+
+  var result: String;
+  unsafe {
+    result = strings.fromNullTerm(value);
+  }
+
+  mem.free(nameBuf as *Void);
+  return result;
 }
 
 pub fun panic(message: String) Void {
-  eprintln(message);
+  io.eprintln(message);
   exit(1);
 }

--- a/std/strings.zp
+++ b/std/strings.zp
@@ -1,6 +1,11 @@
 import "std/string" as string;
 import "std/collection";
 
+import "std/mem";
+import "core" { getDataPtr };
+
+ext fun zap_string_from_cstr(cs: *Char) String;
+
 pub fun split(s: noescape string.StringView,
               delim: Char) collection.List<String> {
   var out: collection.List<String> = new collection.List<String>();
@@ -72,4 +77,20 @@ pub fun splitTrimmed(s: noescape string.StringView,
   }
 
   return out;
+}
+
+pub fun makeNullTerm(str: noescape string.StringView) *Char {
+    var len = string.len(str);
+    var ptr = mem.malloc(len + 1);
+    if ptr != null {
+        unsafe {
+            mem.copy(ptr, getDataPtr(str) as *Void, len);
+            *((ptr as *Char) + len) = '\0';
+        }
+    }
+    return ptr as *Char;
+}
+
+pub unsafe fun fromNullTerm(cs: *Char) String {
+    return zap_string_from_cstr(cs);
 }

--- a/tests/get_env_test.zp
+++ b/tests/get_env_test.zp
@@ -1,0 +1,10 @@
+import "std/process";
+import "std/io";
+
+fun main() Int {
+  var val = process.getEnv("TIP");
+  if (val == "#define struct union") {
+    return 0;
+  }
+  return 1;
+}


### PR DESCRIPTION
### Changes
`std/io`: Implemented `print`, `println`, `eprint` *(new)*, `eprintln`, `print{Int, Char, Float,Float64}` and `flush` using C's stdio functions like fwrite and fflush directly without additional wrappers
`std/math`: Removed useless wrapper functions
`std/process`: Reimplemented `getEnv` in Zap using C's `getenv` and added a test
`std/strings`: Added null-terminated string utilities (`strings.makeNullTerm`, `strings.fromNullTerm`) for interop with C APIs
`std/mem`: Added `memcpy`, `memmove`, and `memset` wrappers (`mem.copy`, `mem.move`, `mem.fill`)
`stdlib.c`: Removed a lot of stuff