### PR TITLE
feat(driver): Add a windows detection function

### DIFF
--- a/src/driver/compiler.hpp
+++ b/src/driver/compiler.hpp
@@ -6,13 +6,9 @@
 
 namespace zap {
 
-///
 /// @brief Name that displays when --help is used.
-///
 constexpr const char *ZAP_NAME = ZAP_NAME_MACRO;
-///
 /// @brief Zap's version, displayed when --version is used.
-///
 constexpr version ZAP_VERSION(0, 4, 1);
 
 } // namespace zap

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -120,6 +120,20 @@ public:
     return true; // Condition is always true.
   }
 
+  /// @brief Returns if the current target is windows.
+  bool is_target_windows() const noexcept {
+    const std::string &tt = get_target_triple();
+    if (tt.empty())
+#ifdef _WIN32
+      return true; // Host target is windows.
+#else
+      return false;
+#endif
+    else
+      return get_target_triple().find(
+          "windows"); // Windows targets have "windows" as the OS set.
+  }
+
   /// @brief Returns a file extension based on the file format given.
   /// @return Read-only string.
   constexpr static const char *
@@ -127,13 +141,8 @@ public:
     switch (type) {
     default:
       [[fallthrough]];
-    case args::OutputType::EXEC: // This should depend on the target set, not
-                                 // host.
-#ifdef _WIN32
-      return ".exe";
-#else
-      return "";
-#endif
+    case args::OutputType::EXEC:
+      return ""; // No .exe because I never seen this being used on executables.
     case args::OutputType::OBJECT:
       return ".o";
     case args::OutputType::ASM:


### PR DESCRIPTION
At least basic detection of whether the target is windows or not.
Also removing the padding comments, they look weird.

Another being the change in `format_fileextension(...)` I have never seen it being used on executables, so I don't see a reason for it having an `#ifdef _WIN32`.